### PR TITLE
Evaluating Syntax Elements + Starting point for builtin definitions

### DIFF
--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -1,0 +1,10 @@
+class FunctionError < StandardError; end
+
+ZIL_BUILTINS = {}
+
+ZIL_BUILTINS[:LVAL] = lambda { |args, context|
+  var_atom = eval_zil args[0], context
+  raise FunctionError, "No local value for #{var_atom}" unless context.locals.key? var_atom
+
+  context.locals[var_atom]
+}

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -15,3 +15,7 @@ ZIL_BUILTINS[:LVAL] = define_for_evaled_args { |args, context|
 
   context.locals[var_atom]
 }
+
+ZIL_BUILTINS[:+] = define_for_evaled_args { |args|
+  args.inject(0, :+)
+}

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -1,21 +1,21 @@
 class FunctionError < StandardError; end
 
-def define_for_evaled_args(&implementation)
-  lambda { |args, context|
-    evaled_args = args.map { |arg| eval_zil arg, context }
-    implementation.call(evaled_args, context)
+def define_for_evaled_arguments(&implementation)
+  lambda { |arguments, context|
+    evaled_arguments = arguments.map { |argument| eval_zil argument, context }
+    implementation.call(evaled_arguments, context)
   }
 end
 
 ZIL_BUILTINS = {}
 
-ZIL_BUILTINS[:LVAL] = define_for_evaled_args { |args, context|
-  var_atom = args[0]
+ZIL_BUILTINS[:LVAL] = define_for_evaled_arguments { |arguments, context|
+  var_atom = arguments[0]
   raise FunctionError, "No local value for #{var_atom.inspect}" unless context.locals.key? var_atom
 
   context.locals[var_atom]
 }
 
-ZIL_BUILTINS[:+] = define_for_evaled_args { |args|
-  args.inject(0, :+)
+ZIL_BUILTINS[:+] = define_for_evaled_arguments { |arguments|
+  arguments.inject(0, :+)
 }

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -1,10 +1,17 @@
 class FunctionError < StandardError; end
 
+def define_for_evaled_args(&implementation)
+  lambda { |args, context|
+    evaled_args = args.map { |arg| eval_zil arg, context }
+    implementation.call(evaled_args, context)
+  }
+end
+
 ZIL_BUILTINS = {}
 
-ZIL_BUILTINS[:LVAL] = lambda { |args, context|
-  var_atom = eval_zil args[0], context
-  raise FunctionError, "No local value for #{var_atom}" unless context.locals.key? var_atom
+ZIL_BUILTINS[:LVAL] = define_for_evaled_args { |args, context|
+  var_atom = args[0]
+  raise FunctionError, "No local value for #{var_atom.inspect}" unless context.locals.key? var_atom
 
   context.locals[var_atom]
 }

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -3,6 +3,8 @@ def eval_zil(expression, zil_context)
   when Numeric, String, Symbol
     expression
   when Syntax::Form
+    return false if expression.elements.empty?
+
     func_atom = expression.elements.first
     func_args = expression.elements.drop(1)
     function = zil_context.globals[func_atom]

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -1,0 +1,3 @@
+def eval_zil(expression, zil_context)
+  # Please implement :D
+end

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -1,6 +1,10 @@
 def eval_zil(expression, zil_context)
   case expression
-  when Numeric, String, Symbol
+  when Numeric, String
+    expression
+  when Symbol
+    return true if expression == :T
+
     expression
   when Syntax::Form
     return false if expression.elements.empty?

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -20,6 +20,8 @@ def eval_zil(expression, zil_context)
   when Syntax::Comment
     nil
   else
-    raise "Cannot eval #{expression}"
+    raise EvalError, "Cannot eval #{expression}"
   end
 end
+
+class EvalError < StandardError; end

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -9,6 +9,8 @@ def eval_zil(expression, zil_context)
     function.call(func_args, zil_context)
   when Syntax::List
     expression.elements.map { |element| eval_zil(element, zil_context) }
+  when Syntax::Quote
+    expression.element
   else
     raise "Cannot eval #{expression}"
   end

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -17,6 +17,8 @@ def eval_zil(expression, zil_context)
     expression.elements.map { |element| eval_zil(element, zil_context) }
   when Syntax::Quote
     expression.element
+  when Syntax::Comment
+    nil
   else
     raise "Cannot eval #{expression}"
   end

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -12,6 +12,8 @@ def eval_zil(expression, zil_context)
     func_atom = expression.elements.first
     func_args = expression.elements.drop(1)
     function = zil_context.globals[func_atom]
+    raise EvalError, "Function #{func_atom} does not exist" unless function
+
     function.call(func_args, zil_context)
   when Syntax::List
     expression.elements.map { |element| eval_zil(element, zil_context) }

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -7,5 +7,9 @@ def eval_zil(expression, zil_context)
     func_args = expression.elements.drop(1)
     function = zil_context.globals[func_atom]
     function.call(func_args, zil_context)
+  when Syntax::List
+    expression.elements.map { |element| eval_zil(element, zil_context) }
+  else
+    raise "Cannot eval #{expression}"
   end
 end

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -1,3 +1,11 @@
 def eval_zil(expression, zil_context)
-  # Please implement :D
+  case expression
+  when Numeric, String, Symbol
+    expression
+  when Syntax::Form
+    func_atom = expression.elements.first
+    func_args = expression.elements.drop(1)
+    function = zil_context.globals[func_atom]
+    function.call(func_args, zil_context)
+  end
 end

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,4 +1,5 @@
 require 'app/syntax.rb'
+require 'app/parser.rb'
 
 def tick(args)
 end

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,5 +1,6 @@
 require 'app/syntax.rb'
 require 'app/parser.rb'
+require 'app/zil_context.rb'
 
 def tick(args)
 end

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,6 +1,7 @@
 require 'app/syntax.rb'
 require 'app/parser.rb'
 require 'app/zil_context.rb'
+require 'app/eval.rb'
 
 def tick(args)
 end

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,5 +1,6 @@
 require 'app/syntax.rb'
 require 'app/parser.rb'
+require 'app/builtins.rb'
 require 'app/zil_context.rb'
 require 'app/eval.rb'
 

--- a/samples/99_zil_interpreter/app/parser.rb
+++ b/samples/99_zil_interpreter/app/parser.rb
@@ -235,7 +235,7 @@ class Scanner
     list = read_list
     raise "DECL inner list is empty!" if list.elements.length < 1
 
-    Syntax::Decl.new(*list.elements) # return inner list as convenience
+    Syntax::Decl.new(list)
   end
 
   def read_expression

--- a/samples/99_zil_interpreter/app/syntax.rb
+++ b/samples/99_zil_interpreter/app/syntax.rb
@@ -39,13 +39,6 @@ module Syntax
     end
   end
 
-  # #DECL (...)
-  class Decl < List
-    def to_s
-      "#DECL(#{@elements.join(' ')})"
-    end
-  end
-
   # Base class for Macro and Quote
   class ElementWrapper
     attr_reader :element
@@ -92,6 +85,13 @@ module Syntax
   class Segment < ElementWrapper
     def to_s
       "!#{@element}"
+    end
+  end
+
+  # #DECL (...)
+  class Decl < ElementWrapper
+    def to_s
+      "#DECL #{@elements}"
     end
   end
 end

--- a/samples/99_zil_interpreter/app/zil_context.rb
+++ b/samples/99_zil_interpreter/app/zil_context.rb
@@ -1,8 +1,7 @@
 def build_zil_context(args)
   args.state.new_entity_strict(
     :zil_context,
-    globals: {},
+    globals: {}.merge(ZIL_BUILTINS),
     locals: {},
   )
 end
-

--- a/samples/99_zil_interpreter/app/zil_context.rb
+++ b/samples/99_zil_interpreter/app/zil_context.rb
@@ -1,0 +1,8 @@
+def build_zil_context(args)
+  args.state.new_entity_strict(
+    :zil_context,
+    globals: {},
+    locals: {},
+  )
+end
+

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -1,0 +1,26 @@
+def test_builtin_lval(args, assert)
+  zil_context = build_zil_context(args)
+  zil_context.locals[:"LOCAL-VAR"] = 22
+
+  # <LVAL LOCAL-VAR>
+  result = zil_context.globals[:LVAL].call [:"LOCAL-VAR"], zil_context
+
+  assert.equal! result, 22
+
+  # Evaluating argument first
+  zil_context.locals[:VARNAME] = :"LOCAL-VAR"
+
+  # <LVAL <LVAL VARNAME>>
+  result = zil_context.globals[:LVAL].call [Syntax::Form.new(:LVAL, :VARNAME)], zil_context
+
+  assert.equal! result, 22
+end
+
+def test_builtin_lval_raises_error_when_not_existing(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.globals[:LVAL].call [:"LOCAL-VAR"], zil_context
+  raise 'No exception occurred'
+rescue FunctionError
+  assert.ok!
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -24,3 +24,12 @@ def test_builtin_lval_raises_error_when_not_existing(args, assert)
 rescue FunctionError
   assert.ok!
 end
+
+def test_builtin_plus(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <+ 1 2 <+ 9 10>>
+  result = zil_context.globals[:+].call [1, 2, Syntax::Form.new(:+, 3, 4)], zil_context
+
+  assert.equal! result, 10
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -59,6 +59,18 @@ def test_eval_list_returns_array_of_evaled_elements(args, assert)
   assert.equal! result, [3, 'String', 14]
 end
 
+def test_eval_vector_returns_array_of_evaled_elements(args, assert)
+  zil_context = build_zil_context(args)
+  zil_context.globals[:ADD] = -> (args, _context) { args[0] + args[1] }
+
+  result = eval_zil(
+    Syntax::Vector.new(3, 'String', Syntax::Form.new(:ADD, 2, 12)),
+    zil_context
+  )
+
+  assert.equal! result, [3, 'String', 14]
+end
+
 def test_eval_quote_returns_wrapped_element(args, assert)
   zil_context = build_zil_context(args)
 

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -1,0 +1,26 @@
+def test_eval_number_returns_itself(args, assert)
+  result = eval_zil(
+    2,
+    build_zil_context(args)
+  )
+
+  assert.equal! result, 2
+end
+
+def test_eval_symbol_returns_itself(args, assert)
+  result = eval_zil(
+    :ATOM,
+    build_zil_context(args)
+  )
+
+  assert.equal! result, :ATOM
+end
+
+def test_eval_string_returns_itself(args, assert)
+  result = eval_zil(
+    'Bob',
+    build_zil_context(args)
+  )
+
+  assert.equal! result, 'Bob'
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -157,6 +157,17 @@ def test_eval_decl_will_raise_exception(args, assert)
   end
 end
 
+def test_eval_nonexisting_function_will_raise_exception(args, assert)
+  zil_context = build_zil_context(args)
+
+  will_raise_eval_error!(assert) do
+    eval_zil(
+      Syntax::Form.new(:IF, :T, 2, 3),
+      zil_context
+    )
+  end
+end
+
 def will_raise_eval_error!(assert)
   raised_exception_class = nil
   begin

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -69,3 +69,14 @@ def test_eval_quote_returns_wrapped_element(args, assert)
 
   assert.equal! result, Syntax::Form.new(:+, 1, 2, 3)
 end
+
+def test_eval_empty_form_returns_false(args, assert)
+  zil_context = build_zil_context(args)
+
+  result = eval_zil(
+    Syntax::Form.new,
+    zil_context
+  )
+
+  assert.equal! result, false
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -24,3 +24,25 @@ def test_eval_string_returns_itself(args, assert)
 
   assert.equal! result, 'Bob'
 end
+
+def test_eval_form_calls_global_value_of_func_atom(args, assert)
+  zil_context = build_zil_context(args)
+  call_args = nil
+  call_context = nil
+  zil_context.globals[:FUNC] = lambda { |args, context|
+    call_args = args
+    call_context = context
+    'return value'
+  }
+
+  result = eval_zil(
+    Syntax::Form.new(:FUNC, 'Bob', 22, Syntax::Form.new),
+    zil_context
+  )
+
+  # Evaluating its arguments should be responsibility of the function
+  # So eval_zil should pass them directly
+  assert.equal! call_args, ['Bob', 22, Syntax::Form.new]
+  assert.equal! call_context, zil_context
+  assert.equal! result, 'return value'
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -114,3 +114,42 @@ def test_eval_comment_returns_nil(args, assert)
 
   assert.equal! result, nil
 end
+
+# Segments should not be evaluated by normal eval but only inside builtin list and string
+# construction functions
+def test_eval_segment_will_raise_exception(args, assert)
+  zil_context = build_zil_context(args)
+
+  will_raise_eval_error!(assert) do
+    eval_zil(
+      Syntax::Segment.new("ABC"),
+      zil_context
+    )
+  end
+end
+
+# Macros should be evaluated not by default eval but inside functions that take unevaluated
+# forms
+def test_eval_macro_will_raise_exception(args, assert)
+  zil_context = build_zil_context(args)
+
+  will_raise_eval_error!(assert) do
+    eval_zil(
+      Syntax::Macro.new(
+        Syntax::Form.new(:IF, :T, 2, 3)
+      ),
+      zil_context
+    )
+  end
+end
+
+def will_raise_eval_error!(assert)
+  raised_exception_class = nil
+  begin
+    yield
+  rescue Exception => e
+    raised_exception_class = e.class
+  end
+
+  assert.equal! raised_exception_class, EvalError, 'it did not raise EvalError'
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -80,3 +80,14 @@ def test_eval_empty_form_returns_false(args, assert)
 
   assert.equal! result, false
 end
+
+def test_eval_atom_T_returns_true(args, assert)
+  zil_context = build_zil_context(args)
+
+  result = eval_zil(
+    :T,
+    zil_context
+  )
+
+  assert.equal! result, true
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -103,3 +103,14 @@ def test_eval_atom_T_returns_true(args, assert)
 
   assert.equal! result, true
 end
+
+def test_eval_comment_returns_nil(args, assert)
+  zil_context = build_zil_context(args)
+
+  result = eval_zil(
+    Syntax::Comment.new(Syntax::Form.new(:TEST, 1, 2)),
+    zil_context
+  )
+
+  assert.equal! result, nil
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -58,3 +58,14 @@ def test_eval_list_returns_array_of_evaled_elements(args, assert)
 
   assert.equal! result, [3, 'String', 14]
 end
+
+def test_eval_quote_returns_wrapped_element(args, assert)
+  zil_context = build_zil_context(args)
+
+  result = eval_zil(
+    Syntax::Quote.new(Syntax::Form.new(:+, 1, 2, 3)),
+    zil_context
+  )
+
+  assert.equal! result, Syntax::Form.new(:+, 1, 2, 3)
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -46,3 +46,15 @@ def test_eval_form_calls_global_value_of_func_atom(args, assert)
   assert.equal! call_context, zil_context
   assert.equal! result, 'return value'
 end
+
+def test_eval_list_returns_array_of_evaled_elements(args, assert)
+  zil_context = build_zil_context(args)
+  zil_context.globals[:ADD] = -> (args, _context) { args[0] + args[1] }
+
+  result = eval_zil(
+    Syntax::List.new(3, 'String', Syntax::Form.new(:ADD, 2, 12)),
+    zil_context
+  )
+
+  assert.equal! result, [3, 'String', 14]
+end

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -143,6 +143,20 @@ def test_eval_macro_will_raise_exception(args, assert)
   end
 end
 
+# Decls should be evaluated not by default eval but only inside function definitions
+def test_eval_decl_will_raise_exception(args, assert)
+  zil_context = build_zil_context(args)
+
+  will_raise_eval_error!(assert) do
+    eval_zil(
+      Syntax::Decl.new(
+        Syntax::Form.new(:IF, :T, 2, 3)
+      ),
+      zil_context
+    )
+  end
+end
+
 def will_raise_eval_error!(assert)
   raised_exception_class = nil
   begin

--- a/samples/99_zil_interpreter/tests/main.rb
+++ b/samples/99_zil_interpreter/tests/main.rb
@@ -1,0 +1,2 @@
+require 'tests/parser_tests.rb'
+require 'tests/parser_tests_basic.rb'

--- a/samples/99_zil_interpreter/tests/main.rb
+++ b/samples/99_zil_interpreter/tests/main.rb
@@ -1,2 +1,3 @@
 require 'tests/parser_tests.rb'
 require 'tests/parser_tests_basic.rb'
+require 'tests/eval_tests.rb'

--- a/samples/99_zil_interpreter/tests/main.rb
+++ b/samples/99_zil_interpreter/tests/main.rb
@@ -1,3 +1,4 @@
 require 'tests/parser_tests.rb'
 require 'tests/parser_tests_basic.rb'
 require 'tests/eval_tests.rb'
+require 'tests/builtins_tests.rb'

--- a/samples/99_zil_interpreter/tests/parser_tests_basic.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests_basic.rb
@@ -303,8 +303,9 @@ def test_parser_15(args, assert)
     :ROUTINE1,
     Syntax::List.new(:P1, :P2, :P3),
     Syntax::Decl.new(
-      Syntax::List.new(:P1, :P2, :P3),
-      :FIX))
+      Syntax::List.new(
+        Syntax::List.new(:P1, :P2, :P3),
+        :FIX)))
 
   assert.equal! parsed, expected
 end


### PR DESCRIPTION
Added a basic `eval_zil` method and a simple underlying `zil_context` data structure.

Functions are supposed to be callable globals which in their most general form take two arguments: The array of unevaluated arguments and the zil context in which it was called

I also added a file for defining builtins - and implemented `LVAL` and `+` as example