### PR TITLE
Updated: Uses Syntax objects, Works with kf unit tests, Added 'basic' unit tests

### DIFF
--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,0 +1,2 @@
+def tick(args)
+end

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,2 +1,4 @@
+require 'app/syntax.rb'
+
 def tick(args)
 end

--- a/samples/99_zil_interpreter/app/parser.rb
+++ b/samples/99_zil_interpreter/app/parser.rb
@@ -1,0 +1,375 @@
+# Parser class uses the scanner to load from file or string buffer. Results are loaded into expressions.
+#
+# Usage:
+#   source = "<ZIL ()>"
+#   parser.parse_string(args, source)
+#   expr0 = parser.expressions[0]
+#
+#   OR
+#
+#   parser.parse_file(args, '/data/zil/zork1/', 'zork1.zil')
+#   expr0 = parser.expressions[0]
+#
+class Parser
+  attr_reader :expressions
+
+  def initialize
+    @expressions = []
+  end
+
+  def parse_file(args, work_dir, file_name)
+    @work_dir = work_dir # not sure if we need work_dir, the idea was to follow INSERT-FILEs inside the parser/scanner
+
+    file = args.gtk.read_file(@work_dir + file_name)
+    log "Opening '" + file_name + "' ..."
+
+    buffer = ""
+    file.each_line.each { |line|
+      line.each_char { |c| buffer << c }
+    }
+
+    log "Scanning '" + file_name + "' ..."
+    scanner = Scanner.new(buffer)
+
+    i = 0
+    while scanner.scan_to('<;"%') # find next form, string, or comment
+      expr = scanner.read_expression
+      @expressions << expr
+      log "[#{file_name}:#{i}] " + expr.to_s
+      i += 1
+    end
+
+    log "Scan completed."
+  end
+
+  def parse_string(args, buffer)
+    log "Scanning buffer ..."
+    scanner = Scanner.new(buffer)
+
+    i = 0
+    while scanner.scan_to('<;"%') # find next form, string, or comment
+      expr = scanner.read_expression
+      @expressions << expr
+      log "[BUFFER:#{i}] " + expr.to_s
+      i += 1
+    end
+
+    log "Scan completed."
+  end
+end
+
+# This class can probably be reworked into Parser:
+#
+# Usage:
+#   scanner = Scanner.new(buffer)
+#   while scanner.scan_to('<;"%') # find next form, string, or comment
+#     expr = scanner.read_expression
+#   end
+#
+class Scanner
+  ATOM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+*/?=.,!$"
+  FIX_CHARS = '0123456789*#' # * = octal, #2 = binary
+  WHITESPACE_CHARS = " \r\n\t"
+
+  def initialize(buffer)
+    @buffer = buffer
+    @expr_depth = 0
+    @list_depth = 0
+    reset
+  end
+
+  def reset
+    @buf_index = -1
+  end
+
+  def scan_to(scan_chars)
+    found = false
+
+    while @buf_index < @buffer.length - 1
+      @buf_index += 1
+      buf_char = @buffer[@buf_index]
+
+      if scan_chars.include?(buf_char)
+        found = true
+        break
+      end
+
+    end
+
+    found
+  end
+
+  def skip_whitespace
+    done = false
+
+    until done
+      break if @buf_index >= @buffer.length
+
+      c = @buffer[@buf_index]
+      if WHITESPACE_CHARS.include?(c) == false
+        done = true
+        break
+      end
+      @buf_index += 1
+    end
+  end
+
+  def peek
+    @buffer[@buf_index]
+  end
+
+  def peek_next
+    @buffer[@buf_index + 1]
+  end
+
+  def peek_string(num)
+    str = ""
+
+    i = 0
+    while i < num
+      str += @buffer[@buf_index + i]
+      i += 1
+    end
+
+    str
+  end
+
+  def is_fix?(char)
+    return false if char.nil?
+
+    if FIX_CHARS.include?(char)
+      true
+    else
+      false
+    end
+  end
+
+  def read_atom
+    atom = ""
+
+    while @buf_index < @buffer.length - 1 # iterate characters in line
+      buf_char = @buffer[@buf_index]
+      @buf_index += 1
+
+      if buf_char == '\\' # observed in this--> <STRING !\" !,WBREAKS>
+        next_char = peek
+        if next_char == '"'
+          atom += read_char
+        end
+      elsif ATOM_CHARS.include?(buf_char)
+        atom += buf_char
+      else
+        @buf_index -= 1
+        break
+      end
+    end
+
+    atom.to_sym
+  end
+
+  def read_char
+    char = @buffer[@buf_index]
+    @buf_index += 1
+    char
+  end
+
+  def read_comment
+    # read comment char, then read the expresson that follows
+    semi = read_char # read in ;
+    comment = read_expression # read commented out stuff and ignore
+
+    Syntax::Comment.new(comment)
+  end
+
+  # %<...>
+  def read_cond_macro
+    pct_char = read_char # read '%'
+    expr = read_expression # read '<...>'
+
+    Syntax::Macro.new(expr)
+  end
+
+  def read_decl
+    hashtag = read_char # read #
+    decl = read_atom # read DECL
+    skip_whitespace
+    list = read_list
+
+    Syntax::Decl.new(*list)
+  end
+
+  def read_expression
+    debug_flag = false
+    @expr_depth += 1
+    raise "Expression recursion overflow" if @expr_depth > 50
+
+    expr_char = peek
+    if expr_char == '<' #  Starts with '<' then read_form
+      log "+ FORM " if debug_flag
+      expr = read_form
+    elsif expr_char == '(' #  Starts with '(' then read_list
+      log "+ LIST " if debug_flag
+      expr = read_list
+    elsif expr_char == '"' #  Starts with '"' then read_string
+      log "+ STRING " if debug_flag
+      expr = read_string
+    elsif expr_char == ';' #  Starts with ';' then read_comment
+      log "+ COMMENT " if debug_flag
+      expr = read_comment
+    elsif expr_char == '#' && peek_string(5) == '#DECL'
+      log "+ DECL " if debug_flag
+      expr = read_decl
+    elsif expr_char == '%' && peek_string(6) == '%<COND'
+      log "+ COND MACRO " if debug_flag
+      expr = read_cond_macro
+    elsif expr_char == "'"
+      log "+ MACRO " if debug_flag
+      expr = read_macro
+    elsif is_fix?(expr_char) # Starts with 0123456789 then read_fix
+      log "+ FIX " if debug_flag
+      expr = read_fix
+    else
+      #  else read atom
+      log "+ ATOM " if debug_flag
+      expr = read_atom
+    end
+
+    @expr_depth -= 1
+    expr
+  end
+
+  def read_fix
+    # UC1: 123456
+    # UC2: *3777*
+    # UC3: #2 0111
+
+    fix = ""
+
+    # step 1: just load the string based on the three types
+    while @buf_index < @buffer.length - 1 # iterate characters in line
+      buf_char = @buffer[@buf_index]
+      @buf_index += 1
+
+      if FIX_CHARS.include?(buf_char)
+        #log "[TMP] " + buf_char
+        fix += buf_char
+      elsif buf_char == " " && fix == '#2'
+        fix += buf_char
+      else
+        @buf_index -= 1
+        break
+      end
+    end
+
+    # step 2: convert to number
+    if fix.start_with?('*')
+      fix = fix.gsub('*', '')
+      fix = fix.to_i(base=8)
+    elsif fix.start_with?('#2')
+      fix = fix.gsub('#2 ', '')
+      fix = fix.to_i(base=2)
+    else
+      fix = fix.to_i
+    end
+
+    fix
+  end
+
+  # <...>
+  def read_form
+    lt = read_char # 1) Read '<'
+    atom = read_atom # 2) Read atom
+    skip_whitespace # 3) Skip whitespace
+
+    # 4) Read params (form, list, string, fix)
+    expr = []
+    last_buf_index = -1 # make sure we don't get into an endless loop
+    done = false
+    until done
+      if @buf_index == last_buf_index # endless loop detected
+        log "ENDLESS at '" + peek + "'"
+        raise "ENDLESS"
+      end
+
+      last_buf_index = @buf_index
+
+      ft = peek
+      if ft == '>' # handle special case of empty form
+        done = true
+      else
+        expr << read_expression
+        #log expr[expr.length - 1]
+      end
+
+      skip_whitespace
+    end
+
+    gt = read_char # 5) Read '>'
+
+    if atom.length == 0 && expr.length == 0
+      Syntax::Form.new # empty Form
+    elsif atom.length != 0 && expr.length == 0
+      Syntax::Form.new(atom) # atom with no params
+    else
+      Syntax::Form.new(*[atom, *expr]) # atom and params
+    end
+  end
+
+  # (...)
+  def read_list
+    @list_depth += 1
+    raise "List overflow" if @list_depth > 50
+
+    lparen = read_char # read '('
+
+    # read contents
+    list = []
+    next_char = peek
+    while next_char != ")"
+      list << read_expression
+      skip_whitespace
+      next_char = peek
+    end
+
+    rparen = read_char # read ')'
+
+    @list_depth -= 1
+    Syntax::List.new(*list)
+  end
+
+  # '<...>
+  def read_macro
+    squot = read_char # read '
+    expr = read_expression # read '<...>'
+
+    Syntax::Quote.new(expr)
+  end
+
+  def read_string
+    quot = read_char # read '"'
+
+    s = ""
+    # read contents
+    while @buf_index < @buffer.length - 1 # iterate characters in line
+      buf_char = @buffer[@buf_index]
+      @buf_index += 1
+
+      # levi use case \' (don't see in ZIL files currently)
+      if buf_char == '\\'
+        next_char = peek
+        if next_char == '"'
+          s += read_char
+        end
+      elsif buf_char != '"'
+        s += buf_char
+      else
+        @buf_index -= 1
+        break
+      end
+    end
+
+    quot = read_char # read '"'
+    s
+  end
+
+end

--- a/samples/99_zil_interpreter/app/syntax.rb
+++ b/samples/99_zil_interpreter/app/syntax.rb
@@ -1,24 +1,4 @@
 module Syntax
-  class Form
-    attr_reader :elements
-
-    def initialize(*elements)
-      @elements = elements
-    end
-
-    def ==(other)
-      other.is_a?(Form) && @elements == other.elements
-    end
-
-    def to_s
-      "<#{@elements.join(' ')}>"
-    end
-
-    def inspect
-      to_s
-    end
-  end
-
   class List
     attr_reader :elements
 
@@ -27,7 +7,7 @@ module Syntax
     end
 
     def ==(other)
-      other.is_a?(List) && @elements == other.elements
+      other.class == self.class && @elements == other.elements
     end
 
     def to_s
@@ -36,6 +16,16 @@ module Syntax
 
     def inspect
       to_s
+    end
+
+    def serialize
+      { type: self.class.name, elements: @elements }
+    end
+  end
+
+  class Form < List
+    def to_s
+      "<#{@elements.join(' ')}>"
     end
   end
 end

--- a/samples/99_zil_interpreter/app/syntax.rb
+++ b/samples/99_zil_interpreter/app/syntax.rb
@@ -1,4 +1,6 @@
+# Contains Syntax tokens of ZIL
 module Syntax
+  # (...)
   class List
     attr_reader :elements
 
@@ -23,9 +25,45 @@ module Syntax
     end
   end
 
+  # <...>
   class Form < List
     def to_s
       "<#{@elements.join(' ')}>"
+    end
+  end
+
+  # Base class for Macro and Quote
+  class ElementWrapper
+    attr_reader :element
+
+    def initialize(element)
+      @element = element
+    end
+
+    def ==(other)
+      other.class == self.class && @element = element
+    end
+
+    def inspect
+      to_s
+    end
+
+    def serialize
+      { type: self.class.name, element: @element }
+    end
+  end
+
+  # %...
+  class Macro < ElementWrapper
+    def to_s
+      "%#{@element}"
+    end
+  end
+
+  # '...
+  class Quote < ElementWrapper
+    def to_s
+      "'#{@element}"
     end
   end
 end

--- a/samples/99_zil_interpreter/app/syntax.rb
+++ b/samples/99_zil_interpreter/app/syntax.rb
@@ -1,0 +1,41 @@
+module Syntax
+  class Form
+    attr_reader :elements
+
+    def initialize(*elements)
+      @elements = elements
+    end
+
+    def ==(other)
+      other.is_a?(Form) && @elements == other.elements
+    end
+
+    def to_s
+      "<#{@elements.join(' ')}>"
+    end
+
+    def inspect
+      to_s
+    end
+  end
+
+  class List
+    attr_reader :elements
+
+    def initialize(*elements)
+      @elements = elements
+    end
+
+    def ==(other)
+      other.is_a?(List) && @elements == other.elements
+    end
+
+    def to_s
+      "(#{@elements.join(' ')})"
+    end
+
+    def inspect
+      to_s
+    end
+  end
+end

--- a/samples/99_zil_interpreter/app/syntax.rb
+++ b/samples/99_zil_interpreter/app/syntax.rb
@@ -32,6 +32,13 @@ module Syntax
     end
   end
 
+  # #DECL (...)
+  class Decl < List
+    def to_s
+      "#DECL#{@elements.join(' ')}>"
+    end
+  end
+
   # Base class for Macro and Quote
   class ElementWrapper
     attr_reader :element
@@ -41,7 +48,7 @@ module Syntax
     end
 
     def ==(other)
-      other.class == self.class && @element = element
+      other.class == self.class && @element == other.element
     end
 
     def inspect
@@ -64,6 +71,13 @@ module Syntax
   class Quote < ElementWrapper
     def to_s
       "'#{@element}"
+    end
+  end
+
+  # ;...
+  class Comment < ElementWrapper
+    def to_s
+      ";#{@element}"
     end
   end
 end

--- a/samples/99_zil_interpreter/tests/parser_tests.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests.rb
@@ -51,3 +51,34 @@ ZIL
 
   assert.equal! parsed, expected
 end
+
+def test_parser_macro_and_quoted(args, assert)
+  source = <<-ZIL
+%<COND (<EQUAL? ,GLOBAL-VAR 22>
+  '<ROUTINE ABC () 3>)
+       (ELSE
+  '<ROUTINE ABC () 4>)>
+ZIL
+
+  parsed = nil  # Call parser here with source
+
+  expected = Syntax::Macro.new(
+    Syntax::Form.new(
+      :COND,
+      Syntax::List.new(
+        Syntax::Form.new(:EQUAL?, :",GLOBAL-VAR", 22),
+        Syntax::Quote.new(
+          Syntax::Form.new(:ROUTINE, :ABC, Syntax::List.new(), 3)
+        ),
+      ),
+      Syntax::List.new(
+        :ELSE,
+        Syntax::Quote.new(
+          Syntax::Form.new(:ROUTINE, :ABC, Syntax::List.new(), 4)
+        )
+      )
+    )
+  )
+
+  assert.equal! parsed, expected
+end

--- a/samples/99_zil_interpreter/tests/parser_tests.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests.rb
@@ -1,6 +1,6 @@
 def test_parser(args, assert)
   source = <<-ZIL
-<ROUTINE OTHER-SIDE (DOBJ "AUX" (P 0) TX) ;"finds room beyond given door"
+<ROUTINE OTHER-SIDE (DOBJ "AUX" (P 0) TX)
  <REPEAT ()
    <COND (<L? <SET P <NEXTP ,HERE .P>> ,LOW-DIRECTION>
     <RETURN <>>)
@@ -11,7 +11,9 @@ def test_parser(args, assert)
            <RETURN .P>)>)>>>
 ZIL
 
-  parsed = nil  # Call parser here with source
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
 
   expected = Syntax::Form.new(
     :ROUTINE,
@@ -60,7 +62,9 @@ def test_parser_macro_and_quoted(args, assert)
   '<ROUTINE ABC () 4>)>
 ZIL
 
-  parsed = nil  # Call parser here with source
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
 
   expected = Syntax::Macro.new(
     Syntax::Form.new(

--- a/samples/99_zil_interpreter/tests/parser_tests.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests.rb
@@ -1,0 +1,53 @@
+def test_parser(args, assert)
+  source = <<-ZIL
+<ROUTINE OTHER-SIDE (DOBJ "AUX" (P 0) TX) ;"finds room beyond given door"
+ <REPEAT ()
+   <COND (<L? <SET P <NEXTP ,HERE .P>> ,LOW-DIRECTION>
+    <RETURN <>>)
+         (ELSE
+    <SET TX <GETPT ,HERE .P>>
+    <COND (<AND <EQUAL? <PTSIZE .TX> ,DEXIT>
+          <EQUAL? <GETB .TX ,DEXITOBJ> .DOBJ>>
+           <RETURN .P>)>)>>>
+ZIL
+
+  parsed = nil  # Call parser here with source
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :"OTHER-SIDE",
+    Syntax::List.new(:DOBJ, "AUX", Syntax::List.new(:P, 0), :TX),
+    Syntax::Form.new(
+      :REPEAT,
+      Syntax::List.new(),
+      Syntax::Form.new(
+        :COND,
+        Syntax::List.new(
+          Syntax::Form.new(
+            :L?,
+            Syntax::Form.new(:SET, :P, Syntax::Form.new(:NEXTP, :",HERE", :".P")),
+            :",LOW-DIRECTION"
+          ),
+          Syntax::Form.new(:RETURN, Syntax::Form.new())
+        ),
+        Syntax::List.new(
+          :ELSE,
+          Syntax::Form.new(:SET, :TX, Syntax::Form.new(:GETPT, :",HERE", :".P")),
+          Syntax::Form.new(
+            :COND,
+            Syntax::List.new(
+              Syntax::Form.new(
+                :AND,
+                Syntax::Form.new(:EQUAL?, Syntax::Form.new(:PTSIZE, :".TX"), :",DEXIT"),
+                Syntax::Form.new(:EQUAL?, Syntax::Form.new(:GETB, :".TX", :",DEXITOBJ"), :".DOBJ")
+              ),
+              Syntax::Form.new(:RETURN, :".P"),
+            )
+          )
+        )
+      )
+    )
+  )
+
+  assert.equal! parsed, expected
+end

--- a/samples/99_zil_interpreter/tests/parser_tests_basic.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests_basic.rb
@@ -1,0 +1,355 @@
+# test basic SETG command with STRING and FIX
+# -----------------------------------------
+def test_parser_01(args, assert)
+  source = <<-ZIL
+<SETG ZORK-NUMBER 1>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :SETG,
+    :"ZORK-NUMBER",
+    1)
+
+  assert.equal! parsed, expected
+end
+
+# test escaped atom
+# -----------------------------------------
+def test_parser_02(args, assert)
+  # need to escape backslash in HEREDOC to get correct result
+  source = <<-ZIL
+<STRING !\\" !,WBREAKS>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :STRING,
+    :"!\"",
+    :"!,WBREAKS"
+  )
+
+  assert.equal! parsed, expected
+end
+
+# test nested forms and escaped atom
+# -----------------------------------------
+def test_parser_03(args, assert)
+  # need to escape backslash to get correct result
+  source = <<-ZIL
+<OR <GASSIGNED? ZILCH>
+    <SETG WBREAKS <STRING !\\" !,WBREAKS>>>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :OR,
+    Syntax::Form.new(
+      :"GASSIGNED?",
+      :"ZILCH"),
+    Syntax::Form.new(
+      :SETG,
+      :"WBREAKS",
+      Syntax::Form.new(
+        :STRING,
+        :'!"',
+        :"!,WBREAKS")))
+
+  assert.equal! parsed, expected
+end
+
+# test string element
+# -----------------------------------------
+def test_parser_04(args, assert)
+  source = <<-ZIL
+<INSERT-FILE "GMACROS" T>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :"INSERT-FILE",
+    "GMACROS",
+    :T)
+
+  assert.equal! parsed, expected
+end
+
+# test list element
+# -----------------------------------------
+def test_parser_05(args, assert)
+  source = <<-ZIL
+<OBJECT ROOMS
+	(IN TO ROOMS)>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :"OBJECT",
+    :"ROOMS",
+    Syntax::List.new(
+      :IN, :TO, :ROOMS
+    )
+  )
+
+  assert.equal! parsed, expected
+end
+
+# test commented string
+# -----------------------------------------
+def test_parser_06(args, assert)
+  source = <<-ZIL
+;"Yes, this synonym for LOCAL-GLOBALS needs to exist... sigh"
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Comment.new(
+    "Yes, this synonym for LOCAL-GLOBALS needs to exist... sigh"
+  )
+
+  assert.equal! parsed, expected
+end
+
+# test commented object
+# -----------------------------------------
+def test_parser_07(args, assert)
+  source = <<-ZIL
+;<SETG ZORK-NUMBER 1>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Comment.new(
+    Syntax::Form.new(
+      :SETG,
+      :"ZORK-NUMBER",
+      1))
+
+  assert.equal! parsed, expected
+end
+
+# test Hello World routine
+# -----------------------------------------
+def test_parser_08(args, assert)
+  source = <<-ZIL
+  <ROUTINE GO ()
+    <PRINTI "Hello, world!">
+    <CRLF>>
+  ZIL
+
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :GO,
+    Syntax::List.new,
+    Syntax::Form.new(:PRINTI, "Hello, world!"),
+    Syntax::Form.new(:CRLF))
+
+  assert.equal! parsed, expected
+end
+
+# test list with atom, string, fix
+# -----------------------------------------
+def test_parser_09(args, assert)
+  source = <<-ZIL
+<ROUTINE WITH-LIST (P "TEST" 0)>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :"WITH-LIST",
+    Syntax::List.new(:P, "TEST", 0)
+  )
+
+  assert.equal! parsed, expected
+end
+
+# test FIX parsing (all varieties: binary octal and decimal)
+# -----------------------------------------
+def test_parser_10(args, assert)
+  source = <<-ZIL
+<ROUTINE WITH-LIST (#2 0011 *17* 123)>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :"WITH-LIST",
+    Syntax::List.new(
+      3, # '#2 0011'
+      15, # '*17*'
+      123) # 123
+  )
+
+  assert.equal! parsed, expected
+end
+
+# test FORM parse with empty FORM element
+# -----------------------------------------
+def test_parser_11(args, assert)
+  source = <<-ZIL
+  <RETURN <>>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :RETURN,
+    Syntax::Form.new)
+
+  assert.equal! parsed, expected
+end
+
+# test FORM parse with empty LIST element
+# -----------------------------------------
+def test_parser_12(args, assert)
+  source = <<-ZIL
+  <RETURN (() ()) ()>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :RETURN,
+    Syntax::List.new(
+      Syntax::List.new,
+      Syntax::List.new),
+    Syntax::List.new)
+
+  assert.equal! parsed, expected
+end
+
+# test multiline string
+# -----------------------------------------
+def test_parser_13(args, assert)
+  source = <<-ZIL
+  <TELL
+"You are standing in an open field west of a white house, with a boarded
+front door.">
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :TELL,
+    "You are standing in an open field west of a white house, with a boarded\nfront door.")
+
+  assert.equal! parsed, expected
+end
+
+# test multiline string with escape chars
+# -----------------------------------------
+def test_parser_14(args, assert)
+  # need to escape backslash to get correct result
+  source = <<-ZIL
+  <TELL
+"You are standing in an \\"open\\" field west of a white house, with a boarded
+front door.">
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :TELL,
+    "You are standing in an \"open\" field west of a white house, with a boarded\nfront door.")
+
+  assert.equal! parsed, expected
+end
+
+# test DECL for routine
+# -----------------------------------------
+def test_parser_15(args, assert)
+  source = <<-ZIL
+<ROUTINE ROUTINE1 (P1 P2 P3)
+	 #DECL ((P1 P2 P3) FIX)
+>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :ROUTINE1,
+    Syntax::List.new(:P1, :P2, :P3),
+    Syntax::Decl.new(
+      Syntax::List.new(
+        Syntax::List.new(:P1, :P2, :P3),
+        :FIX)))
+
+  assert.equal! parsed, expected
+end
+
+# test Macro/Quote for routine
+# -----------------------------------------
+def test_parser_16(args, assert)
+  source = <<-ZIL
+<ROUTINE V-WISH ()
+	 %<COND (<==? ,ZORK-NUMBER 2>
+		 '<PERFORM ,V?MAKE ,WISH>)
+		(T
+		 '<TELL "With luck, your wish will come true." CR>)>>
+  ZIL
+  parser = Parser.new
+  parser.parse_string(args, source)
+  parsed = parser.expressions[0]
+
+  expected = Syntax::Form.new(
+    :ROUTINE,
+    :"V-WISH",
+    Syntax::List.new,
+    Syntax::Macro.new(
+      Syntax::Form.new(
+        :COND,
+        Syntax::List.new(
+          Syntax::Form.new(
+            :"==?", :",ZORK-NUMBER", 2),
+          Syntax::Quote.new(
+            Syntax::Form.new(
+              :PERFORM, :",V?MAKE", :",WISH")
+          )
+        ),
+        Syntax::List.new(
+          :T,
+          Syntax::Quote.new(
+            Syntax::Form.new(
+              :TELL, "With luck, your wish will come true.", :CR)
+          )
+        )
+      )
+    )
+  )
+
+  assert.equal! parsed, expected
+end


### PR DESCRIPTION
Use valid ZIL as error handling is not great.  

- Parses all Zork 1 files and all unit tests.  
- Likely need to clean up some of the 'log' statements for console cleanliness.
- Next step is to add invalid ZIL and work through error cases/reporting.