### PR TITLE
Parser bugfix, Eval for TrueClass/FalseClass, Logic builtins #I

### DIFF
--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -163,7 +163,10 @@ ZIL_BUILTINS[:COND] = lambda { |arguments, context|
   #
   raise FunctionError, "COND requires at least one parameter!" unless arguments.length > 0
 
-  arguments.each { |clause|
+  i = 0
+  while i < arguments.length
+    clause = arguments[i]
+
     raise FunctionError, "Arguments to COND must be of List type!" unless clause.class == Syntax::List
     raise FunctionError, "COND clauses require at least 1 item!" unless clause.elements.length > 0
 
@@ -174,7 +177,8 @@ ZIL_BUILTINS[:COND] = lambda { |arguments, context|
       }
       return clause_eval
     end
-  }
+    i += 1
+  end
 
   false
 }

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -85,3 +85,97 @@ ZIL_BUILTINS[:RANDOM] = define_for_evaled_arguments { |arguments|
   range = arguments[0]
   rand(range) + 1
 }
+
+# <MOD ...>
+ZIL_BUILTINS[:MOD] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "MOD only supported with 2 argument!" if arguments.length != 2
+  raise FunctionError, "MOD only supported with FIX argument types!" if arguments[0].class != Fixnum || arguments[1].class != Fixnum
+  arguments[0] % arguments[1]
+}
+
+# <0? ...>
+ZIL_BUILTINS[:"0?"] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "0? only supported with 1 argument!" if arguments.length != 1
+  arguments[0] == 0 || arguments[0] == 0.0
+}
+
+# <1? ...>
+ZIL_BUILTINS[:"1?"] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "1? only supported with 1 argument!" if arguments.length != 1
+  arguments[0] == 1 || arguments[0] == 1.0
+}
+
+# <G? ...>
+ZIL_BUILTINS[:G?] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "G? only supported with 2 arguments!" if arguments.length != 2
+  arguments[0] > arguments[1]
+}
+
+# <L? ...>
+ZIL_BUILTINS[:L?] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "L? only supported with 2 arguments!" if arguments.length != 2
+  arguments[0] < arguments[1]
+}
+
+# <AND ...> (FSUBR)
+ZIL_BUILTINS[:AND] = lambda { |arguments, context|
+  result = false
+  arguments.each { |a|
+    result = eval_zil(a, context)
+    return false if result == false
+  }
+  result
+}
+
+# <AND? ...> (SUBR)
+ZIL_BUILTINS[:AND?] = define_for_evaled_arguments { |arguments|
+  result = false
+  arguments.each { |a|
+    result = a
+    return false if a == false
+  }
+  result
+}
+
+# <OR ...>  (FSUBR)
+ZIL_BUILTINS[:OR] = lambda { |arguments, context|
+  arguments.each { |a|
+    result = eval_zil(a, context)
+    return result unless result == false
+  }
+  false
+}
+
+# <OR? ...>  (SUBR)
+ZIL_BUILTINS[:OR?] = define_for_evaled_arguments { |arguments|
+  arguments.each { |a|
+    return a unless a == false
+  }
+  false
+}
+
+# <COND () ...> (FSUBR)
+ZIL_BUILTINS[:COND] = lambda { |arguments, context|
+  # COND goes walking down its clauses, EVALing the first element of each clause,
+  # looking for a non-FALSE result. As soon as it finds a non-FALSE, it forgets
+  # about all the other clauses and evaluates, in order, the other elements of
+  # the current clause and returns the last thing it evaluates.
+  #
+  raise FunctionError, "COND requires at least one parameter!" unless arguments.length > 0
+
+  arguments.each { |clause|
+    raise FunctionError, "Arguments to COND must be of List type!" unless clause.class == Syntax::List
+    raise FunctionError, "COND clauses require at least 1 item!" unless clause.elements.length > 0
+
+    clause_eval = eval_zil(clause.elements[0], context)
+    if clause_eval != false # eval 0th element for non-false
+      clause.elements.drop(1).each { |clause_element|
+        clause_eval = eval_zil(clause_element, context)
+      }
+      return clause_eval
+    end
+  }
+
+  false
+}
+

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -117,6 +117,12 @@ ZIL_BUILTINS[:L?] = define_for_evaled_arguments { |arguments|
   arguments[0] < arguments[1]
 }
 
+# <NOT ...>
+ZIL_BUILTINS[:NOT] = define_for_evaled_arguments { |arguments|
+  raise FunctionError, "NOT only supported with 1 argument!" if arguments.length != 1
+  arguments[0] == false
+}
+
 # <AND ...> (FSUBR)
 ZIL_BUILTINS[:AND] = lambda { |arguments, context|
   result = false

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -1,6 +1,8 @@
 def eval_zil(expression, zil_context)
   case expression
-  when Numeric, String
+  when Numeric, String, TrueClass, FalseClass
+    # ZIL expressions can eval to true (:T), so true must eval to true
+    # ZIL expressions can eval to false (FALSE, #FALSE), so false must continue to eval to false
     expression
   when Symbol
     return true if expression == :T

--- a/samples/99_zil_interpreter/app/parser.rb
+++ b/samples/99_zil_interpreter/app/parser.rb
@@ -151,6 +151,8 @@ class Scanner
 
     if char == '*' && FIX_CHARS.include?(next_char) == false # make sure this isn't the multiply operator ('*' followed by whitespace)
       false
+    elsif next_char == '?' # special case for 0? and 1? atoms
+      false
     elsif FIX_CHARS.include?(char)
       true
     else

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -339,6 +339,30 @@ def test_builtin_less(args, assert)
   assert.equal! result, false
 end
 
+def test_builtin_not(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <NOT>
+  begin
+    zil_context.globals[:NOT].call [], zil_context
+    raise 'No exception occurred when invoking "NOT" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <NOT T>
+  result = zil_context.globals[:NOT].call [:T], zil_context
+  assert.equal! result, false, '<NOT T>'
+
+  # <NOT <NOT T>>
+  result = zil_context.globals[:NOT].call [Syntax::Form.new(:NOT, :T)], zil_context
+  assert.equal! result, true, '<NOT <NOT T>>'
+
+  # <NOT <NOT NOT<T>>>
+  result = zil_context.globals[:NOT].call [Syntax::Form.new(:NOT, Syntax::Form.new(:NOT, :T))], zil_context
+  assert.equal! result, false, '<NOT <NOT NOT<T>>>'
+end
+
 def test_builtin_and(args, assert)
   zil_context = build_zil_context(args)
 

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -166,3 +166,329 @@ def test_builtin_random(args, assert)
     assert.ok!
   end
 end
+
+def test_builtin_mod(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <MOD> !!
+  begin
+    zil_context.globals[:MOD].call [], zil_context
+    raise 'No exception occurred when invoking MOD with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <MOD 1> !!
+  begin
+    zil_context.globals[:MOD].call [1], zil_context
+    raise 'No exception occurred when invoking MOD one argument!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <MOD 1 1.5> !!
+  begin
+    zil_context.globals[:MOD].call [1, 1.5], zil_context
+    raise 'No exception occurred when invoking MOD with Float!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <MOD 5 2>
+  result = zil_context.globals[:MOD].call [5, 2], zil_context
+  assert.equal! result, 1
+
+  # <MOD 20 7>
+  result = zil_context.globals[:MOD].call [20, 7], zil_context
+  assert.equal! result, 6
+end
+
+def test_builtin_0?(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <0?> !!
+  begin
+    zil_context.globals[:"0?"].call [], zil_context
+    raise 'No exception occurred when invoking "0?" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <0? 1 2> !!
+  begin
+    zil_context.globals[:"0?"].call [1, 2], zil_context
+    raise 'No exception occurred when invoking "0?" more than one argument!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <0? 0>
+  result = zil_context.globals[:"0?"].call [0], zil_context
+  assert.equal! result, true
+
+  # <0? 0.0>
+  result = zil_context.globals[:"0?"].call [0.0], zil_context
+  assert.equal! result, true
+
+  # <0? 1>
+  result = zil_context.globals[:"0?"].call [1], zil_context
+  assert.equal! result, false
+
+  # <0? 1.0>
+  result = zil_context.globals[:"0?"].call [1.0], zil_context
+  assert.equal! result, false
+end
+
+def test_builtin_1?(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <1?> !!
+  begin
+    zil_context.globals[:"1?"].call [], zil_context
+    raise 'No exception occurred when invoking "1?" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <1? 1 2> !!
+  begin
+    zil_context.globals[:"1?"].call [1, 2], zil_context
+    raise 'No exception occurred when invoking "1?" more than one argument!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <1? 0>
+  result = zil_context.globals[:"1?"].call [0], zil_context
+  assert.equal! result, false
+
+  # <1? 0.0>
+  result = zil_context.globals[:"1?"].call [0.0], zil_context
+  assert.equal! result, false
+
+  # <1? 1>
+  result = zil_context.globals[:"1?"].call [1], zil_context
+  assert.equal! result, true
+
+  # <1? 1.0>
+  result = zil_context.globals[:"1?"].call [1.0], zil_context
+  assert.equal! result, true
+end
+
+def test_builtin_greater(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <G?> !!
+  begin
+    zil_context.globals[:G?].call [], zil_context
+    raise 'No exception occurred when invoking "1?" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <G? 1> !!
+  begin
+    zil_context.globals[:G?].call [1], zil_context
+    raise 'No exception occurred when invoking "1?" with one argument!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <G? 0 0>
+  result = zil_context.globals[:G?].call [0, 0], zil_context
+  assert.equal! result, false
+
+  # <G? 0 1>
+  result = zil_context.globals[:G?].call [0, 1], zil_context
+  assert.equal! result, false
+
+  # <G? 1 0>
+  result = zil_context.globals[:G?].call [1, 0], zil_context
+  assert.equal! result, true
+end
+
+def test_builtin_less(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <L?> !!
+  begin
+    zil_context.globals[:L?].call [], zil_context
+    raise 'No exception occurred when invoking "1?" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <L? 1> !!
+  begin
+    zil_context.globals[:L?].call [1], zil_context
+    raise 'No exception occurred when invoking "1?" with one argument!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <L? 0 0>
+  result = zil_context.globals[:L?].call [0, 0], zil_context
+  assert.equal! result, false
+
+  # <L? 0 1>
+  result = zil_context.globals[:L?].call [0, 1], zil_context
+  assert.equal! result, true
+
+  # <L? 1 0>
+  result = zil_context.globals[:L?].call [1, 0], zil_context
+  assert.equal! result, false
+end
+
+def test_builtin_and(args, assert)
+  zil_context = build_zil_context(args)
+
+  # "Anything which is not FALSE, is, reasonably enough, true."
+  # "If none of them evaluate to FALSE, it returns EVAL of its last argument."
+
+  # <AND 0 0>
+  result = zil_context.globals[:AND].call [0, 0], zil_context
+  assert.equal! result, 0, '<AND 0 0> = 0'
+
+  # <AND false 0>
+  result = zil_context.globals[:AND].call [false, 0], zil_context
+  assert.equal! result, false, '<AND false 0> = false'
+
+  # <AND 0 false>
+  result = zil_context.globals[:AND].call [0, false], zil_context
+  assert.equal! result, false, '<AND 0 false> = false'
+
+  # <AND "false" "false">
+  result = zil_context.globals[:AND].call ["false", "false"], zil_context
+  assert.equal! result, "false", '<AND "false" "false"> = "false"'
+
+  # <AND <0? 0> <1? 1>>
+  result = zil_context.globals[:AND].call [Syntax::Form.new(:"0?", 0), Syntax::Form.new(:"1?", 1)], zil_context
+  assert.equal! result, true, '<AND <0? 0> <1? 1>> = true'
+
+  # <AND <0? 1> <1? 1>>
+  result = zil_context.globals[:AND].call [Syntax::Form.new(:"0?", 1), Syntax::Form.new(:"1?", 1)], zil_context
+  assert.equal! result, false, '<AND <0? 1> <1? 1>> = false'
+end
+
+def test_builtin_and?(args, assert)
+  zil_context = build_zil_context(args)
+
+  # "Anything which is not FALSE, is, reasonably enough, true."
+  # "If none of them evaluate to FALSE, it returns EVAL of its last argument."
+
+  # this unit test would be a little better if we counted evals somewhere.
+  # that way we could prove there more evals.
+
+  # <AND? 0 0>
+  result = zil_context.globals[:AND].call [0, 0], zil_context
+  assert.equal! result, 0, '<AND? 0 0> = 0'
+
+  # <AND? false 0>
+  result = zil_context.globals[:AND].call [false, 0], zil_context
+  assert.equal! result, false, '<AND? false 0> = false'
+
+  # <AND? 0 false>
+  result = zil_context.globals[:AND].call [0, false], zil_context
+  assert.equal! result, false, '<AND? 0 false> = false'
+
+  # <AND? "false" "false">
+  result = zil_context.globals[:AND].call ["false", "false"], zil_context
+  assert.equal! result, "false", '<AND? "false" "false"> = "false"'
+
+  # <AND? <0? 0> <1? 1>>
+  result = zil_context.globals[:AND].call [Syntax::Form.new(:"0?", 0), Syntax::Form.new(:"1?", 1)], zil_context
+  assert.equal! result, true, '<AND? <0? 0> <1? 1>> = true'
+
+  # <AND? <0? 1> <1? 1>>
+  result = zil_context.globals[:AND].call [Syntax::Form.new(:"0?", 1), Syntax::Form.new(:"1?", 1)], zil_context
+  assert.equal! result, false, '<AND? <0? 1> <1? 1>> = false'
+end
+
+def test_builtin_cond(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <COND>
+  begin
+    zil_context.globals[:COND].call [], zil_context
+    raise 'No exception occurred when invoking "COND" with no arguments!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <COND ()>
+  begin
+    clause1 = Syntax::List.new
+    zil_context.globals[:COND].call [clause1], zil_context
+    raise 'No exception occurred when invoking "COND" with empty clauses!'
+  rescue FunctionError
+    assert.ok!
+  end
+
+  # <COND (<0? 1>)> --> Nothing evals to true, so COND returns FALSE
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 1))
+  result = zil_context.globals[:COND].call [clause1], zil_context
+  assert.equal! result, false, '<COND (<0? 1>)> != false'
+
+  # <COND (<0? 1>) (<0? 1>)> --> Nothing evals to true, so COND returns FALSE
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 1))
+  clause2 = Syntax::List.new(Syntax::Form.new(:"0?", 1))
+  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  assert.equal! result, false, '<COND (<0? 1>) (<0? 1>)> != false'
+
+  # <COND (<0? 0>)> --> Evals to true, even though no elements in the clause are evaled
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0))
+  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  assert.equal! result, true, '<COND (<0? 0>)> == false'
+
+  # Setup for next set of tests
+  zil_context.locals[:VAR10] = 10
+  zil_context.locals[:VAR20] = 20
+  zil_context.locals[:VAR30] = 30
+  zil_context.locals[:VAR_T] = true
+  zil_context.locals[:VAR_F] = false
+
+  # <COND (<0? 0> .VAR10 .VAR20)> --> Evals to 20
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20))
+  result = zil_context.globals[:COND].call [clause1], zil_context
+  assert.equal! result, 20, 'Last element of clause should be returned! (20)'
+
+  # <COND (<0? 0> .VAR10 .VAR20 .VAR10)> --> Evals to 20
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20), Syntax::Form.new(:LVAL, :VAR10))
+  result = zil_context.globals[:COND].call [clause1], zil_context
+  assert.equal! result, 10, 'Last element of clause should be returned! (10)'
+
+  # <COND (<0? 0> .VAR10 .VAR20 .VAR10 .VAR_F .VAR30)> --> Evals to false because :VAR_F is false
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR_F), Syntax::Form.new(:LVAL, :VAR30))
+  result = zil_context.globals[:COND].call [clause1], zil_context
+  assert.equal! result, 30, 'Last element of clause should be returned! (30)'
+
+  # <COND (<0? 0> .VAR10 .VAR20 .VAR_F .VAR10)> --> Evals to false because :VAR_F is false
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR_F))
+  result = zil_context.globals[:COND].call [clause1], zil_context
+  assert.equal! result, false, 'Last element of clause should be returned! (false)'
+
+  # <COND (<0? 0> .VAR10) (<0? 0> .VAR20)> --> Evals to 10
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10))
+  clause2 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR20))
+  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  assert.equal! result, 10, 'First cond should be evaled and returned'
+
+  # <COND (<0? 1> .VAR10) (T .VAR20)> --> Evals to 20
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 1), Syntax::Form.new(:LVAL, :VAR10))
+  clause2 = Syntax::List.new(:T, Syntax::Form.new(:LVAL, :VAR20))
+  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  assert.equal! result, 20, 'Else T returns 20'
+
+  # <COND (<0? 1> .VAR10) (<1? 0> .VAR20) (T .VAR30)> --> Evals to 30
+  clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 1), Syntax::Form.new(:LVAL, :VAR10))
+  clause2 = Syntax::List.new(Syntax::Form.new(:"1?", 0), Syntax::Form.new(:LVAL, :VAR20))
+  clause3 = Syntax::List.new(:T, Syntax::Form.new(:LVAL, :VAR30))
+  result = zil_context.globals[:COND].call [clause1, clause2, clause3], zil_context
+  assert.equal! result, 30, 'Else T returns 30'
+
+  # <COND (.VAR_F .VAR10) (.VAR_T .VAR20)> --> Evals to 30
+  clause1 = Syntax::List.new(Syntax::Form.new(:LVAL, :VAR_F), Syntax::Form.new(:LVAL, :VAR10))
+  clause2 = Syntax::List.new(Syntax::Form.new(:LVAL, :VAR_T), Syntax::Form.new(:LVAL, :VAR20))
+  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  assert.equal! result, 20, 'Else T returns 20 (2)'
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -437,7 +437,7 @@ def test_builtin_cond(args, assert)
 
   # <COND (<0? 0>)> --> Evals to true, even though no elements in the clause are evaled
   clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0))
-  result = zil_context.globals[:COND].call [clause1, clause2], zil_context
+  result = zil_context.globals[:COND].call [clause1], zil_context
   assert.equal! result, true, '<COND (<0? 0>)> == false'
 
   # Setup for next set of tests
@@ -452,7 +452,7 @@ def test_builtin_cond(args, assert)
   result = zil_context.globals[:COND].call [clause1], zil_context
   assert.equal! result, 20, 'Last element of clause should be returned! (20)'
 
-  # <COND (<0? 0> .VAR10 .VAR20 .VAR10)> --> Evals to 20
+  # <COND (<0? 0> .VAR10 .VAR20 .VAR10)> --> Evals to 10
   clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20), Syntax::Form.new(:LVAL, :VAR10))
   result = zil_context.globals[:COND].call [clause1], zil_context
   assert.equal! result, 10, 'Last element of clause should be returned! (10)'
@@ -462,7 +462,7 @@ def test_builtin_cond(args, assert)
   result = zil_context.globals[:COND].call [clause1], zil_context
   assert.equal! result, 30, 'Last element of clause should be returned! (30)'
 
-  # <COND (<0? 0> .VAR10 .VAR20 .VAR_F .VAR10)> --> Evals to false because :VAR_F is false
+  # <COND (<0? 0> .VAR10 .VAR20 .VAR_F)> --> Evals to false because :VAR_F is false
   clause1 = Syntax::List.new(Syntax::Form.new(:"0?", 0), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR20), Syntax::Form.new(:LVAL, :VAR10), Syntax::Form.new(:LVAL, :VAR_F))
   result = zil_context.globals[:COND].call [clause1], zil_context
   assert.equal! result, false, 'Last element of clause should be returned! (false)'

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -178,3 +178,28 @@ def will_raise_eval_error!(assert)
 
   assert.equal! raised_exception_class, EvalError, 'it did not raise EvalError'
 end
+
+def test_eval_internal_true_returns_true(args, assert)
+  zil_context = build_zil_context(args)
+
+  # the atom :T evals to true. That result might be later eval'ed: meaning true must eval to true
+  result = eval_zil(
+    true,
+
+    zil_context
+  )
+
+  assert.equal! result, true
+end
+
+def test_eval_internal_false_returns_false(args, assert)
+  zil_context = build_zil_context(args)
+
+  # builtins like AND can return false, false must eval to false
+  result = eval_zil(
+    false,
+    zil_context
+  )
+
+  assert.equal! result, false
+end

--- a/samples/99_zil_interpreter/tests/parser_tests_basic.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests_basic.rb
@@ -448,10 +448,18 @@ def test_parser_23(args, assert)
 <* 1 2 3>
   ZIL
   parsed = Parser.parse_string(source)[0]
+  expected = Syntax::Form.new(:*, 1, 2, 3)
+  assert.equal! parsed, expected
+end
 
-  expected = Syntax::Form.new(
-    :*, 1, 2, 3
-  )
+# test 0? atom
+# --------------------------------------------------------------------
+def test_parser_24(args, assert)
+  source = <<-ZIL
+<0? 1>
+  ZIL
+  parsed = Parser.parse_string(source)[0]
+  expected = Syntax::Form.new(:"0?", 1)
 
   assert.equal! parsed, expected
 end


### PR DESCRIPTION
New items:

- Parser bugfix for 0?, 1?
- Eval updates for TrueClass/FalseClass
- Builtins: MOD, 0?, 1?, G?, L?, AND, AND?, OR, OR?, COND, and NOT