### PR TITLE
Implement Table/List builtin functions

### DIFF
--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -338,13 +338,13 @@ ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
 
 ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   array_like_value = arguments[0]
-  offset = arguments[1]
+  offset = arguments[1] || 1
   ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
 ZIL_BUILTINS[:BACK] = lambda { |arguments, context|
   array_like_value = arguments[0]
-  offset = arguments[1]
+  offset = arguments[1] || 1
   ZIL_BUILTINS[:REST].call [array_like_value, -offset], context
 }
 

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -265,7 +265,7 @@ ZIL_BUILTINS[:COND] = lambda { |arguments, context|
 ZIL_BUILTINS[:OBJECT] = define_for_evaled_arguments { |arguments, context|
   # Objects have a name, and a list of properties and values
   expect_minimum_argument_count!(arguments, 1)
-  
+
   object_name, *object_properties = arguments
 
   object = { properties: {} }
@@ -282,3 +282,22 @@ ZIL_BUILTINS[:OBJECT] = define_for_evaled_arguments { |arguments, context|
   context.globals[object_name] = object
 }
 
+ZIL_BUILTINS[:ITABLE] = lambda { |arguments, context|
+  size = eval_zil arguments[0], context
+  flags = eval_zil arguments[1], context
+  unevaled_default_values = arguments[2..-1]
+  if flags == [:LEXV]
+    default_values = [
+      eval_zil(unevaled_default_values[0], context),
+      0,
+      unevaled_default_values[1].element,
+      unevaled_default_values[2].element
+    ]
+    [size, 0] + default_values * size
+  elsif flags.include? :BYTE
+    default_values = [eval_zil(unevaled_default_values[0], context)]
+    result = default_values * size
+    result.insert(0, size) if flags.include? :LENGTH
+    result
+  end
+}

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -350,3 +350,41 @@ ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
   table[index - 1] = value
   table
 }
+
+ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
+  array_like_value = arguments[0]
+  offset = arguments[1]
+  ArrayWithOffset.from(array_like_value, offset: offset)
+}
+
+class ArrayWithOffset
+  attr_reader :original_array, :offset
+
+  def initialize(original_array, offset:)
+    @original_array = original_array
+    @offset = offset
+  end
+
+  def [](index)
+    @original_array[@offset + index]
+  end
+
+  def []=(index, value)
+    @original_array[@offset + index] = value
+  end
+
+  def to_a
+    @original_array[@offset..-1]
+  end
+
+  def self.from(value, offset:)
+    case value
+    when Array
+      new(value, offset: offset)
+    when ArrayWithOffset
+      new(value.original_array, offset: offset + value.offset)
+    else
+      raise "REST not supported for #{value}"
+    end
+  end
+end

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -283,44 +283,16 @@ ZIL_BUILTINS[:OBJECT] = define_for_evaled_arguments { |arguments, context|
 }
 
 ZIL_BUILTINS[:TABLE] = define_for_evaled_arguments { |arguments|
-  if arguments[0].is_a? Array
-    flags = arguments[0]
-    values = arguments[1..-1]
-  else
-    flags = []
-    values = arguments.dup
-  end
+  flags, values = ZIL::Table.get_flags_and_values arguments
 
-  if flags.include?(:BYTE)
-    values.tap { |result|
-      result.insert(0, result.size) if flags.include? :LENGTH
-    }
-  else
-    [].tap { |result|
-      values.each do |value|
-        if value.is_a? Syntax::Byte
-          result << value.element
-        else
-          result << value
-          result << 0
-        end
-      end
-      if flags.include?(:LENGTH)
-        result.insert(0, result.size.idiv(2))
-        result.insert(1, 0)
-      elsif flags.include?(:LEXV)
-        result.insert(0, result.size.idiv(4))
-        result.insert(1, 0)
-      end
-    }
-  end
+  ZIL::Table.build flags: flags, values: values
 }
 
-ZIL_BUILTINS[:ITABLE] = lambda { |arguments, context|
-  size = eval_zil arguments[0], context
-  flags = arguments[1]
-  unevaled_default_values = arguments[2..-1]
-  ZIL_BUILTINS[:TABLE].call [flags] + unevaled_default_values * size, context
+ZIL_BUILTINS[:ITABLE] = define_for_evaled_arguments { |arguments|
+  size = arguments[0]
+  flags, default_values = ZIL::Table.get_flags_and_values arguments[1..-1]
+
+  ZIL::Table.build flags: flags, values: default_values * size
 }
 
 ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -363,6 +363,11 @@ ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
   ArrayWithOffset.from(array_like_value, offset: -offset)
 }
 
+ZIL_BUILTINS[:EMPTY?] = define_for_evaled_arguments { |arguments|
+  array_like_value = arguments[0]
+  array_like_value.empty?
+}
+
 class ArrayWithOffset
   attr_reader :original_array, :offset
 

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -339,7 +339,7 @@ ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
 ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   array_like_value = arguments[0]
   offset = arguments[1] || 1
-  ArrayWithOffset.from(array_like_value, offset: offset)
+  ZIL::ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
 ZIL_BUILTINS[:BACK] = lambda { |arguments, context|
@@ -370,48 +370,3 @@ ZIL_BUILTINS[:PUTREST] = define_for_evaled_arguments { |arguments|
   array_like_value[1..-1] = new_rest.dup
   array_like_value
 }
-
-class ArrayWithOffset
-  attr_reader :original_array, :offset
-
-  def initialize(original_array, offset:)
-    @original_array = original_array
-    @offset = offset
-  end
-
-  def [](index)
-    @original_array[with_offset(index)]
-  end
-
-  def []=(index, value)
-    @original_array[with_offset(index)] = value
-  end
-
-  def to_a
-    @original_array[@offset..-1]
-  end
-
-  def self.from(value, offset:)
-    case value
-    when Array
-      new(value, offset: offset)
-    when ArrayWithOffset
-      new(value.original_array, offset: offset + value.offset)
-    else
-      raise "REST not supported for #{value}"
-    end
-  end
-
-  private
-
-  def with_offset(index)
-    case index
-    when Integer
-      return index if index.negative? # Don't offset index relative to the end
-
-      index + @offset
-    when Range
-      Range.new(with_offset(index.begin), with_offset(index.end), index.exclude_end?)
-    end
-  end
-end

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -350,10 +350,10 @@ ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   ZIL::ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
-ZIL_BUILTINS[:BACK] = lambda { |arguments, context|
+ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
   array_like_value = arguments[0]
   offset = arguments[1] || 1
-  ZIL_BUILTINS[:REST].call [array_like_value, -offset], context
+  ZIL::ArrayWithOffset.from(array_like_value, offset: -offset)
 }
 
 ZIL_BUILTINS[:EMPTY?] = lambda { |arguments, context|

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -357,6 +357,12 @@ ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
+ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
+  array_like_value = arguments[0]
+  offset = arguments[1]
+  ArrayWithOffset.from(array_like_value, offset: -offset)
+}
+
 class ArrayWithOffset
   attr_reader :original_array, :offset
 

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -294,8 +294,16 @@ ZIL_BUILTINS[:TABLE] = define_for_evaled_arguments { |arguments|
 }
 
 ZIL_BUILTINS[:ITABLE] = define_for_evaled_arguments { |arguments|
-  size = arguments[0]
-  flags, default_values = ZIL::Table.get_flags_and_values arguments[1..-1]
+  if arguments[0].is_a? Symbol
+    specifier = arguments[0]
+    raise "ITABLE Specifier #{specifier} not yet supported" unless specifier == :NONE
+
+    size = arguments[1]
+    flags, default_values = ZIL::Table.get_flags_and_values arguments[2..-1]
+  else
+    size = arguments[0]
+    flags, default_values = ZIL::Table.get_flags_and_values arguments[1..-1]
+  end
 
   ZIL::Table.build flags: flags, values: default_values * size
 }

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -295,6 +295,13 @@ ZIL_BUILTINS[:ITABLE] = define_for_evaled_arguments { |arguments|
   ZIL::Table.build flags: flags, values: default_values * size
 }
 
+ZIL_BUILTINS[:LTABLE] = define_for_evaled_arguments { |arguments|
+  flags, values = ZIL::Table.get_flags_and_values arguments
+  flags << :LENGTH unless flags.include? :LENGTH
+
+  ZIL::Table.build flags: flags, values: values
+}
+
 ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -282,6 +282,11 @@ ZIL_BUILTINS[:OBJECT] = define_for_evaled_arguments { |arguments, context|
   context.globals[object_name] = object
 }
 
+# Tables are represented internally as arrays which contain "bytes" which can be set/get with PUTB/GETB
+# Every other data type is saved as a "word" so basically 2 bytes -
+# but for convenience's sake those words are just stored as two byte elements: [value, 0]
+# Since in Zork single bytes of words are never accessed - nor vice-versa - this kind of representation
+# should be fine.
 ZIL_BUILTINS[:TABLE] = define_for_evaled_arguments { |arguments|
   flags, values = ZIL::Table.get_flags_and_values arguments
 
@@ -336,6 +341,9 @@ ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
   table[one_based_index - 1]
 }
 
+# REST and BACK are using a special ZIL::ArrayWithOffset object which implements
+# the element accessor ([] and []=) which respect the offset but modify the original
+# array
 ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   array_like_value = arguments[0]
   offset = arguments[1] || 1

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -330,6 +330,12 @@ ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
   table
 }
 
+ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
+  table = arguments[0]
+  one_based_index = arguments[1]
+  table[one_based_index - 1]
+}
+
 ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   array_like_value = arguments[0]
   offset = arguments[1]

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -322,3 +322,9 @@ ZIL_BUILTINS[:ITABLE] = lambda { |arguments, context|
   unevaled_default_values = arguments[2..-1]
   ZIL_BUILTINS[:TABLE].call [flags] + unevaled_default_values * size, context
 }
+
+ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
+  table = arguments[0]
+  index = arguments[1]
+  table[index * 2] # Double the index since table stores bytes
+}

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -357,10 +357,10 @@ ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
   ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
-ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
+ZIL_BUILTINS[:BACK] = lambda { |arguments, context|
   array_like_value = arguments[0]
   offset = arguments[1]
-  ArrayWithOffset.from(array_like_value, offset: -offset)
+  ZIL_BUILTINS[:REST].call [array_like_value, -offset], context
 }
 
 ZIL_BUILTINS[:EMPTY?] = lambda { |arguments, context|

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -326,27 +326,27 @@ ZIL_BUILTINS[:ITABLE] = lambda { |arguments, context|
 ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
-  table[index * 2] # Double the index since table stores bytes
+  table[(index - 1) * 2] # Double the index since table stores bytes
 }
 
 ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
-  table[index * 2] = value # Double the index since table stores bytes
+  table[(index - 1) * 2] = value # Double the index since table stores bytes
   table
 }
 
 ZIL_BUILTINS[:GETB] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
-  table[index]
+  table[index - 1]
 }
 
 ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
-  table[index] = value
+  table[index - 1] = value
   table
 }

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -326,28 +326,28 @@ ZIL_BUILTINS[:ITABLE] = lambda { |arguments, context|
 ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
-  table[(index - 1) * 2] # Double the index since table stores bytes
+  table[index * 2] # Double the index since table stores bytes
 }
 
 ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
-  table[(index - 1) * 2] = value # Double the index since table stores bytes
+  table[index * 2] = value # Double the index since table stores bytes
   table
 }
 
 ZIL_BUILTINS[:GETB] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
-  table[index - 1]
+  table[index]
 }
 
 ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
-  table[index - 1] = value
+  table[index] = value
   table
 }
 

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -363,9 +363,20 @@ ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
   ArrayWithOffset.from(array_like_value, offset: -offset)
 }
 
-ZIL_BUILTINS[:EMPTY?] = define_for_evaled_arguments { |arguments|
+ZIL_BUILTINS[:EMPTY?] = lambda { |arguments, context|
   array_like_value = arguments[0]
-  array_like_value.empty?
+  ZIL_BUILTINS[:LENGTH].call([array_like_value], context).zero?
+}
+
+ZIL_BUILTINS[:LENGTH] = define_for_evaled_arguments { |arguments|
+  array_like_value = arguments[0]
+  array_like_value.size
+}
+
+ZIL_BUILTINS[:LENGTH?] = lambda { |arguments, context|
+  array_like_value = arguments[0]
+  length_max = arguments[1]
+  ZIL_BUILTINS[:LENGTH].call([array_like_value], context) <= length_max
 }
 
 class ArrayWithOffset

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -336,3 +336,17 @@ ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
   table[index * 2] = value # Double the index since table stores bytes
   table
 }
+
+ZIL_BUILTINS[:GETB] = define_for_evaled_arguments { |arguments|
+  table = arguments[0]
+  index = arguments[1]
+  table[index]
+}
+
+ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
+  table = arguments[0]
+  index = arguments[1]
+  value = arguments[2]
+  table[index] = value
+  table
+}

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -308,12 +308,16 @@ ZIL_BUILTINS[:LTABLE] = define_for_evaled_arguments { |arguments|
 }
 
 ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 2
+
   table = arguments[0]
   index = arguments[1]
   table[index * 2] # Double the index since table stores bytes
 }
 
 ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 3
+
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
@@ -322,12 +326,16 @@ ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
 }
 
 ZIL_BUILTINS[:GETB] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 2
+
   table = arguments[0]
   index = arguments[1]
   table[index]
 }
 
 ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 3
+
   table = arguments[0]
   index = arguments[1]
   value = arguments[2]
@@ -336,6 +344,8 @@ ZIL_BUILTINS[:PUTB] = define_for_evaled_arguments { |arguments|
 }
 
 ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 2
+
   table = arguments[0]
   one_based_index = arguments[1]
   table[one_based_index - 1]
@@ -345,34 +355,46 @@ ZIL_BUILTINS[:NTH] = define_for_evaled_arguments { |arguments|
 # the element accessor ([] and []=) which respect the offset but modify the original
 # array
 ZIL_BUILTINS[:REST] = define_for_evaled_arguments { |arguments|
+  expect_argument_count_in_range! arguments, (1..2)
+
   array_like_value = arguments[0]
   offset = arguments[1] || 1
   ZIL::ArrayWithOffset.from(array_like_value, offset: offset)
 }
 
 ZIL_BUILTINS[:BACK] = define_for_evaled_arguments { |arguments|
+  expect_argument_count_in_range! arguments, (1..2)
+
   array_like_value = arguments[0]
   offset = arguments[1] || 1
   ZIL::ArrayWithOffset.from(array_like_value, offset: -offset)
 }
 
 ZIL_BUILTINS[:EMPTY?] = lambda { |arguments, context|
+  expect_argument_count! arguments, 1
+
   array_like_value = arguments[0]
   ZIL_BUILTINS[:LENGTH].call([array_like_value], context).zero?
 }
 
 ZIL_BUILTINS[:LENGTH] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 1
+
   array_like_value = arguments[0]
   array_like_value.size
 }
 
 ZIL_BUILTINS[:LENGTH?] = lambda { |arguments, context|
+  expect_argument_count! arguments, 2
+
   array_like_value = arguments[0]
   length_max = arguments[1]
   ZIL_BUILTINS[:LENGTH].call([array_like_value], context) <= length_max
 }
 
 ZIL_BUILTINS[:PUTREST] = define_for_evaled_arguments { |arguments|
+  expect_argument_count! arguments, 2
+
   array_like_value = arguments[0]
   new_rest = arguments[1]
   array_like_value[1..-1] = new_rest.dup

--- a/samples/99_zil_interpreter/app/builtins.rb
+++ b/samples/99_zil_interpreter/app/builtins.rb
@@ -328,3 +328,11 @@ ZIL_BUILTINS[:GET] = define_for_evaled_arguments { |arguments|
   index = arguments[1]
   table[index * 2] # Double the index since table stores bytes
 }
+
+ZIL_BUILTINS[:PUT] = define_for_evaled_arguments { |arguments|
+  table = arguments[0]
+  index = arguments[1]
+  value = arguments[2]
+  table[index * 2] = value # Double the index since table stores bytes
+  table
+}

--- a/samples/99_zil_interpreter/app/eval.rb
+++ b/samples/99_zil_interpreter/app/eval.rb
@@ -1,6 +1,6 @@
 def eval_zil(expression, zil_context)
   case expression
-  when Numeric, String, TrueClass, FalseClass
+  when Numeric, String, TrueClass, FalseClass, Syntax::Byte
     # ZIL expressions can eval to true (:T), so true must eval to true
     # ZIL expressions can eval to false (FALSE, #FALSE), so false must continue to eval to false
     expression

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,4 +1,4 @@
-require 'zil/table.rb'
+require 'zil.rb'
 require 'app/syntax.rb'
 require 'app/parser.rb'
 require 'app/builtins.rb'

--- a/samples/99_zil_interpreter/app/main.rb
+++ b/samples/99_zil_interpreter/app/main.rb
@@ -1,3 +1,4 @@
+require 'zil/table.rb'
 require 'app/syntax.rb'
 require 'app/parser.rb'
 require 'app/builtins.rb'

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -205,7 +205,7 @@ def test_builtin_btst(args, assert)
   result = zil_context.globals[:BTST].call [128, 128], nil
 
   assert.true! result
-  
+
   result = zil_context.globals[:BTST].call [127, 128], nil
 
   assert.false! result
@@ -587,7 +587,6 @@ def test_builtin_object(args, assert)
   result = call_routine zil_context, :OBJECT, specs
   assert.equal! zil_context.globals[:ROOM][:name], :ROOM, "Object's name should be ROOM"
   assert.equal! zil_context.globals[:ROOM][:properties][:HEIGHT], 10, "ROOM's HEIGHT should be 10"
-
 end
 
 def test_builtin_itable(args, assert)

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -709,3 +709,27 @@ def test_builtin_rest(args, assert)
 
   assert.equal! result, 4
 end
+
+def test_builtin_back(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
+
+  # <PUTB <BACK <REST ,THETABLE 2> 1> 1 99>
+  result = call_routine zil_context, :PUTB, [
+    form(:BACK, form(:REST, form(:LVAL, :THETABLE), 2), 1),
+    1,
+    99
+  ]
+
+  assert.equal! result.to_a, [99, 3, 4, 5]
+  assert.equal! zil_context.locals[:THETABLE], [1, 99, 3, 4, 5]
+
+  # <GETB <BACK <REST ,THETABLE 2> 2> 2>
+  result = call_routine zil_context, :GETB, [
+    form(:BACK, form(:REST, form(:LVAL, :THETABLE), 2), 2),
+    1
+  ]
+
+  assert.equal! result, 1
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -672,3 +672,40 @@ def test_builtin_putb(args, assert)
   assert.equal! result, [99, 2, 3]
   assert.equal! zil_context.locals[:THETABLE], [99, 2, 3]
 end
+
+def test_builtin_rest(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
+
+  # <PUTB <REST ,THETABLE 2> 1 99>
+  result = call_routine zil_context, :PUTB, [form(:REST, form(:LVAL, :THETABLE), 2), 1, 99]
+
+  assert.equal! result.to_a, [99, 4, 5]
+  assert.equal! zil_context.locals[:THETABLE], [1, 2, 99, 4, 5]
+
+  # <GETB <REST ,THETABLE 2> 2>
+  result = call_routine zil_context, :GETB, [form(:REST, form(:LVAL, :THETABLE), 2), 2]
+
+  assert.equal! result, 4
+
+  zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
+
+  # <PUTB <REST <REST ,THETABLE 2> 1> 2 100>
+  result = call_routine zil_context, :PUTB, [
+    form(:REST, form(:REST, form(:LVAL, :THETABLE), 2), 1),
+    2,
+    100
+  ]
+
+  assert.equal! result.to_a, [4, 100]
+  assert.equal! zil_context.locals[:THETABLE], [1, 2, 3, 4, 100]
+
+  # <GETB <REST <REST ,THETABLE 1> 2> 1>
+  result = call_routine zil_context, :GETB, [
+    form(:REST, form(:REST, form(:LVAL, :THETABLE), 1), 2),
+    1
+  ]
+
+  assert.equal! result, 4
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -630,3 +630,13 @@ def test_builtin_table(args, assert)
 
   assert.equal! result, [3, 0, 1, 0, 2, 0, 3, 0]
 end
+
+def test_builtin_get(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 0, 2, 0, 3, 0]
+  # <GET ,THETABLE 2>
+  result = call_routine zil_context, :GET, [form(:LVAL, :THETABLE), 2]
+
+  assert.equal! result, 3
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -640,3 +640,14 @@ def test_builtin_get(args, assert)
 
   assert.equal! result, 3
 end
+
+def test_builtin_put(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 0, 2, 0, 3, 0]
+  # <PUT ,THETABLE 1 99>
+  result = call_routine zil_context, :PUT, [form(:LVAL, :THETABLE), 1, 99]
+
+  assert.equal! result, [1, 0, 99, 0, 3, 0]
+  assert.equal! zil_context.locals[:THETABLE], [1, 0, 99, 0, 3, 0]
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -682,6 +682,16 @@ def test_builtin_putb(args, assert)
   assert.equal! zil_context.locals[:THETABLE], [1, 99, 3]
 end
 
+def test_builtin_nth(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3]
+  # <NTH ,THETABLE 2>
+  result = call_routine zil_context, :NTH, [form(:LVAL, :THETABLE), 2]
+
+  assert.equal! result, 2
+end
+
 def test_builtin_rest(args, assert)
   zil_context = build_zil_context(args)
 

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -638,7 +638,7 @@ def test_builtin_get(args, assert)
   # <GET ,THETABLE 2>
   result = call_routine zil_context, :GET, [form(:LVAL, :THETABLE), 2]
 
-  assert.equal! result, 2
+  assert.equal! result, 3
 end
 
 def test_builtin_put(args, assert)
@@ -648,8 +648,8 @@ def test_builtin_put(args, assert)
   # <PUT ,THETABLE 1 99>
   result = call_routine zil_context, :PUT, [form(:LVAL, :THETABLE), 1, 99]
 
-  assert.equal! result, [99, 0, 2, 0, 3, 0]
-  assert.equal! zil_context.locals[:THETABLE], [99, 0, 2, 0, 3, 0]
+  assert.equal! result, [1, 0, 99, 0, 3, 0]
+  assert.equal! zil_context.locals[:THETABLE], [1, 0, 99, 0, 3, 0]
 end
 
 def test_builtin_getb(args, assert)
@@ -659,7 +659,7 @@ def test_builtin_getb(args, assert)
   # <GETB ,THETABLE 2>
   result = call_routine zil_context, :GETB, [form(:LVAL, :THETABLE), 2]
 
-  assert.equal! result, 2
+  assert.equal! result, 3
 end
 
 def test_builtin_putb(args, assert)
@@ -669,8 +669,8 @@ def test_builtin_putb(args, assert)
   # <PUTB ,THETABLE 1 99>
   result = call_routine zil_context, :PUTB, [form(:LVAL, :THETABLE), 1, 99]
 
-  assert.equal! result, [99, 2, 3]
-  assert.equal! zil_context.locals[:THETABLE], [99, 2, 3]
+  assert.equal! result, [1, 99, 3]
+  assert.equal! zil_context.locals[:THETABLE], [1, 99, 3]
 end
 
 def test_builtin_rest(args, assert)
@@ -681,30 +681,30 @@ def test_builtin_rest(args, assert)
   # <PUTB <REST ,THETABLE 2> 1 99>
   result = call_routine zil_context, :PUTB, [form(:REST, form(:LVAL, :THETABLE), 2), 1, 99]
 
-  assert.equal! result.to_a, [99, 4, 5]
-  assert.equal! zil_context.locals[:THETABLE], [1, 2, 99, 4, 5]
+  assert.equal! result.to_a, [3, 99, 5]
+  assert.equal! zil_context.locals[:THETABLE], [1, 2, 3, 99, 5]
 
   # <GETB <REST ,THETABLE 2> 2>
   result = call_routine zil_context, :GETB, [form(:REST, form(:LVAL, :THETABLE), 2), 2]
 
-  assert.equal! result, 4
+  assert.equal! result, 5
 
   zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
 
-  # <PUTB <REST <REST ,THETABLE 2> 1> 2 100>
+  # <PUTB <REST <REST ,THETABLE 2> 1> 1 100>
   result = call_routine zil_context, :PUTB, [
     form(:REST, form(:REST, form(:LVAL, :THETABLE), 2), 1),
-    2,
+    1,
     100
   ]
 
   assert.equal! result.to_a, [4, 100]
   assert.equal! zil_context.locals[:THETABLE], [1, 2, 3, 4, 100]
 
-  # <GETB <REST <REST ,THETABLE 1> 2> 1>
+  # <GETB <REST <REST ,THETABLE 1> 2> 0>
   result = call_routine zil_context, :GETB, [
     form(:REST, form(:REST, form(:LVAL, :THETABLE), 1), 2),
-    1
+    0
   ]
 
   assert.equal! result, 4
@@ -722,8 +722,8 @@ def test_builtin_back(args, assert)
     99
   ]
 
-  assert.equal! result.to_a, [99, 3, 4, 5]
-  assert.equal! zil_context.locals[:THETABLE], [1, 99, 3, 4, 5]
+  assert.equal! result.to_a, [2, 99, 4, 5]
+  assert.equal! zil_context.locals[:THETABLE], [1, 2, 99, 4, 5]
 
   # <GETB <BACK <REST ,THETABLE 2> 2> 2>
   result = call_routine zil_context, :GETB, [
@@ -731,7 +731,7 @@ def test_builtin_back(args, assert)
     1
   ]
 
-  assert.equal! result, 1
+  assert.equal! result, 2
 end
 
 def test_builtin_empty(args, assert)

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -631,6 +631,15 @@ def test_builtin_table(args, assert)
   assert.equal! result, [3, 0, 1, 0, 2, 0, 3, 0]
 end
 
+def test_builtin_ltable(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <LTABLE 2 3 "abc">
+  result = call_routine zil_context, :LTABLE, [2, 3, 'abc']
+
+  assert.equal! result, [3, 0, 2, 0, 3, 0, 'abc', 0] # Adds length in front
+end
+
 def test_builtin_get(args, assert)
   zil_context = build_zil_context(args)
 

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -610,6 +610,14 @@ def test_builtin_itable(args, assert)
     3, # Prefixed with record count
     8, 8, 8
   ]
+
+  # <ITABLE NONE 3>
+  # Word table by default - no length prefix
+  result = call_routine zil_context, :ITABLE, [:NONE, 3]
+
+  assert.equal! result, [
+    0, 0, 0, 0, 0, 0
+  ]
 end
 
 def test_builtin_table(args, assert)

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -589,3 +589,25 @@ def test_builtin_object(args, assert)
   assert.equal! zil_context.globals[:ROOM][:properties][:HEIGHT], 10, "ROOM's HEIGHT should be 10"
 
 end
+
+def test_builtin_itable(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <ITABLE 2 (LEXV) 0 #BYTE 1 #BYTE 2>
+  result = call_routine zil_context, :ITABLE, [2, list(:LEXV), 0, byte(1), byte(2)]
+
+  # LEXV table is prefixed with 2 bytes and has 4 byte records
+  assert.equal! result, [
+    2, 0, # Prefixed with record count and zero byte
+    0, 0, 1, 2,
+    0, 0, 1, 2
+  ]
+
+  # <ITABLE 3 (BYTE LENGTH) 8>
+  result = call_routine zil_context, :ITABLE, [3, list(:BYTE, :LENGTH), 8]
+
+  assert.equal! result, [
+    3, # Prefixed with record count
+    8, 8, 8
+  ]
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -648,6 +648,8 @@ def test_builtin_get(args, assert)
   result = call_routine zil_context, :GET, [form(:LVAL, :THETABLE), 2]
 
   assert.equal! result, 3
+
+  assert_function_error_with_argument_counts! zil_context, :GET, [0, 1, 3]
 end
 
 def test_builtin_put(args, assert)
@@ -659,6 +661,8 @@ def test_builtin_put(args, assert)
 
   assert.equal! result, [1, 0, 99, 0, 3, 0]
   assert.equal! zil_context.locals[:THETABLE], [1, 0, 99, 0, 3, 0]
+
+  assert_function_error_with_argument_counts! zil_context, :PUT, [0, 1, 2, 4]
 end
 
 def test_builtin_getb(args, assert)
@@ -669,6 +673,8 @@ def test_builtin_getb(args, assert)
   result = call_routine zil_context, :GETB, [form(:LVAL, :THETABLE), 2]
 
   assert.equal! result, 3
+
+  assert_function_error_with_argument_counts! zil_context, :GETB, [0, 1, 3]
 end
 
 def test_builtin_putb(args, assert)
@@ -680,6 +686,8 @@ def test_builtin_putb(args, assert)
 
   assert.equal! result, [1, 99, 3]
   assert.equal! zil_context.locals[:THETABLE], [1, 99, 3]
+
+  assert_function_error_with_argument_counts! zil_context, :PUTB, [0, 1, 2, 4]
 end
 
 def test_builtin_nth(args, assert)
@@ -690,6 +698,8 @@ def test_builtin_nth(args, assert)
   result = call_routine zil_context, :NTH, [form(:LVAL, :THETABLE), 2]
 
   assert.equal! result, 2
+
+  assert_function_error_with_argument_counts! zil_context, :NTH, [0, 1, 3]
 end
 
 def test_builtin_rest(args, assert)
@@ -738,6 +748,8 @@ def test_builtin_rest(args, assert)
   raise 'No FunctionError was raised when RESTing past last element'
 rescue FunctionError
   assert.ok!
+
+  assert_function_error_with_argument_counts! zil_context, :REST, [0, 3]
 end
 
 def test_builtin_back(args, assert)
@@ -767,6 +779,8 @@ def test_builtin_back(args, assert)
   raise 'No FunctionError was raised when BACKing past first element'
 rescue FunctionError
   assert.ok!
+
+  assert_function_error_with_argument_counts! zil_context, :BACK, [0, 3]
 end
 
 def test_builtin_empty(args, assert)
@@ -784,6 +798,8 @@ def test_builtin_empty(args, assert)
   result = call_routine zil_context, :EMPTY?, [form(:LVAL, :NONEMPTYTABLE)]
 
   assert.false! result
+
+  assert_function_error_with_argument_counts! zil_context, :EMPTY?, [0, 2]
 end
 
 def test_builtin_length(args, assert)
@@ -800,6 +816,8 @@ def test_builtin_length(args, assert)
   result = call_routine zil_context, :LENGTH, [form(:REST, form(:LVAL, :SOMETABLE))]
 
   assert.equal! result, 2
+
+  assert_function_error_with_argument_counts! zil_context, :LENGTH, [0, 2]
 end
 
 def test_builtin_length_less_than_or_equal(args, assert)
@@ -816,6 +834,8 @@ def test_builtin_length_less_than_or_equal(args, assert)
   result = call_routine zil_context, :LENGTH?, [form(:LVAL, :SOMETABLE), 2]
 
   assert.false! result
+
+  assert_function_error_with_argument_counts! zil_context, :LENGTH?, [0, 1, 3]
 end
 
 def test_builtin_putrest(args, assert)
@@ -840,4 +860,6 @@ def test_builtin_putrest(args, assert)
 
   assert.equal! result.to_a, [98, 50]
   assert.equal! zil_context.locals[:THETABLE], [1, 1, 99, 98, 50]
+
+  assert_function_error_with_argument_counts! zil_context, :PUTREST, [0, 1, 3]
 end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -750,3 +750,30 @@ def test_builtin_empty(args, assert)
 
   assert.false! result
 end
+
+def test_builtin_length(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:SOMETABLE] = [3, 7, 12]
+
+  # <LENGTH ,SOMETABLE>
+  result = call_routine zil_context, :LENGTH, [form(:LVAL, :SOMETABLE)]
+
+  assert.equal! result, 3
+end
+
+def test_builtin_length_less_than_or_equal(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:SOMETABLE] = [3, 7, 12]
+
+  # <LENGTH? ,SOMETABLE 3>
+  result = call_routine zil_context, :LENGTH?, [form(:LVAL, :SOMETABLE), 3]
+
+  assert.true! result
+
+  # <LENGTH? ,SOMETABLE 2>
+  result = call_routine zil_context, :LENGTH?, [form(:LVAL, :SOMETABLE), 2]
+
+  assert.false! result
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -651,3 +651,24 @@ def test_builtin_put(args, assert)
   assert.equal! result, [1, 0, 99, 0, 3, 0]
   assert.equal! zil_context.locals[:THETABLE], [1, 0, 99, 0, 3, 0]
 end
+
+def test_builtin_getb(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3]
+  # <GETB ,THETABLE 2>
+  result = call_routine zil_context, :GETB, [form(:LVAL, :THETABLE), 2]
+
+  assert.equal! result, 3
+end
+
+def test_builtin_putb(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3]
+  # <PUTB ,THETABLE 1 99>
+  result = call_routine zil_context, :PUTB, [form(:LVAL, :THETABLE), 1, 99]
+
+  assert.equal! result, [1, 99, 3]
+  assert.equal! zil_context.locals[:THETABLE], [1, 99, 3]
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -796,3 +796,27 @@ def test_builtin_length_less_than_or_equal(args, assert)
 
   assert.false! result
 end
+
+def test_builtin_putrest(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
+
+  # <PUTREST ,THETABLE (1 1 1)>
+  result = call_routine zil_context, :PUTREST, [form(:LVAL, :THETABLE), list(1, 1, 1)]
+
+  assert.equal! result.to_a, [1, 1, 1, 1]
+  assert.equal! zil_context.locals[:THETABLE], [1, 1, 1, 1]
+
+  # <PUTREST <REST ,THETABLE> (99 98)>
+  result = call_routine zil_context, :PUTREST, [form(:REST, form(:LVAL, :THETABLE)), list(99, 98)]
+
+  assert.equal! result.to_a, [1, 99, 98]
+  assert.equal! zil_context.locals[:THETABLE], [1, 1, 99, 98]
+
+  # <PUTREST <REST ,THETABLE 3> (50)>
+  result = call_routine zil_context, :PUTREST, [form(:REST, form(:LVAL, :THETABLE), 3), list(50)]
+
+  assert.equal! result.to_a, [98, 50]
+  assert.equal! zil_context.locals[:THETABLE], [1, 1, 99, 98, 50]
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -727,6 +727,17 @@ def test_builtin_rest(args, assert)
   ]
 
   assert.equal! result, 4
+
+  # <REST ,THETABLE 5>
+  result = call_routine zil_context, :REST, [form(:LVAL, :THETABLE), 5]
+
+  assert.equal! result.to_a, []
+
+  # <REST ,THETABLE 6>
+  call_routine zil_context, :REST, [form(:LVAL, :THETABLE), 6]
+  raise 'No FunctionError was raised when RESTing past last element'
+rescue FunctionError
+  assert.ok!
 end
 
 def test_builtin_back(args, assert)
@@ -751,6 +762,11 @@ def test_builtin_back(args, assert)
   ]
 
   assert.equal! result, 2
+
+  call_routine zil_context, :BACK, [form(:LVAL, :THETABLE)]
+  raise 'No FunctionError was raised when BACKing past first element'
+rescue FunctionError
+  assert.ok!
 end
 
 def test_builtin_empty(args, assert)

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -710,9 +710,9 @@ def test_builtin_rest(args, assert)
 
   zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
 
-  # <PUTB <REST <REST ,THETABLE 2> 1> 1 100>
+  # <PUTB <REST <REST ,THETABLE 2>> 1 100>
   result = call_routine zil_context, :PUTB, [
-    form(:REST, form(:REST, form(:LVAL, :THETABLE), 2), 1),
+    form(:REST, form(:REST, form(:LVAL, :THETABLE), 2)),
     1,
     100
   ]
@@ -720,9 +720,9 @@ def test_builtin_rest(args, assert)
   assert.equal! result.to_a, [4, 100]
   assert.equal! zil_context.locals[:THETABLE], [1, 2, 3, 4, 100]
 
-  # <GETB <REST <REST ,THETABLE 1> 2> 0>
+  # <GETB <REST <REST ,THETABLE> 2> 0>
   result = call_routine zil_context, :GETB, [
-    form(:REST, form(:REST, form(:LVAL, :THETABLE), 1), 2),
+    form(:REST, form(:REST, form(:LVAL, :THETABLE)), 2),
     0
   ]
 
@@ -734,9 +734,9 @@ def test_builtin_back(args, assert)
 
   zil_context.locals[:THETABLE] = [1, 2, 3, 4, 5]
 
-  # <PUTB <BACK <REST ,THETABLE 2> 1> 1 99>
+  # <PUTB <BACK <REST ,THETABLE 2>> 1 99>
   result = call_routine zil_context, :PUTB, [
-    form(:BACK, form(:REST, form(:LVAL, :THETABLE), 2), 1),
+    form(:BACK, form(:REST, form(:LVAL, :THETABLE), 2)),
     1,
     99
   ]

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -733,3 +733,20 @@ def test_builtin_back(args, assert)
 
   assert.equal! result, 1
 end
+
+def test_builtin_empty(args, assert)
+  zil_context = build_zil_context(args)
+
+  zil_context.locals[:EMPTYTABLE] = []
+  zil_context.locals[:NONEMPTYTABLE] = [1]
+
+  # <EMPTY? ,EMPTYTABLE>
+  result = call_routine zil_context, :EMPTY?, [form(:LVAL, :EMPTYTABLE)]
+
+  assert.true! result
+
+  # <EMPTY? ,NONEMPTYTABLE>
+  result = call_routine zil_context, :EMPTY?, [form(:LVAL, :NONEMPTYTABLE)]
+
+  assert.false! result
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -638,7 +638,7 @@ def test_builtin_get(args, assert)
   # <GET ,THETABLE 2>
   result = call_routine zil_context, :GET, [form(:LVAL, :THETABLE), 2]
 
-  assert.equal! result, 3
+  assert.equal! result, 2
 end
 
 def test_builtin_put(args, assert)
@@ -648,8 +648,8 @@ def test_builtin_put(args, assert)
   # <PUT ,THETABLE 1 99>
   result = call_routine zil_context, :PUT, [form(:LVAL, :THETABLE), 1, 99]
 
-  assert.equal! result, [1, 0, 99, 0, 3, 0]
-  assert.equal! zil_context.locals[:THETABLE], [1, 0, 99, 0, 3, 0]
+  assert.equal! result, [99, 0, 2, 0, 3, 0]
+  assert.equal! zil_context.locals[:THETABLE], [99, 0, 2, 0, 3, 0]
 end
 
 def test_builtin_getb(args, assert)
@@ -659,7 +659,7 @@ def test_builtin_getb(args, assert)
   # <GETB ,THETABLE 2>
   result = call_routine zil_context, :GETB, [form(:LVAL, :THETABLE), 2]
 
-  assert.equal! result, 3
+  assert.equal! result, 2
 end
 
 def test_builtin_putb(args, assert)
@@ -669,6 +669,6 @@ def test_builtin_putb(args, assert)
   # <PUTB ,THETABLE 1 99>
   result = call_routine zil_context, :PUTB, [form(:LVAL, :THETABLE), 1, 99]
 
-  assert.equal! result, [1, 99, 3]
-  assert.equal! zil_context.locals[:THETABLE], [1, 99, 3]
+  assert.equal! result, [99, 2, 3]
+  assert.equal! zil_context.locals[:THETABLE], [99, 2, 3]
 end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -611,3 +611,22 @@ def test_builtin_itable(args, assert)
     8, 8, 8
   ]
 end
+
+def test_builtin_table(args, assert)
+  zil_context = build_zil_context(args)
+
+  # <TABLE <> <> <> <>>
+  result = call_routine zil_context, :TABLE, [form, form, form, form]
+
+  assert.equal! result, [false, 0, false, 0, false, 0, false, 0]
+
+  # <TABLE 8 #BYTE 2 #BYTE 5>
+  result = call_routine zil_context, :TABLE, [8, byte(2), byte(5)]
+
+  assert.equal! result, [8, 0, 2, 5]
+
+  # <TABLE (LENGTH) 1 2 3>
+  result = call_routine zil_context, :TABLE, [list(:LENGTH), 1, 2, 3]
+
+  assert.equal! result, [3, 0, 1, 0, 2, 0, 3, 0]
+end

--- a/samples/99_zil_interpreter/tests/builtins_tests.rb
+++ b/samples/99_zil_interpreter/tests/builtins_tests.rb
@@ -779,6 +779,11 @@ def test_builtin_length(args, assert)
   result = call_routine zil_context, :LENGTH, [form(:LVAL, :SOMETABLE)]
 
   assert.equal! result, 3
+
+  # <LENGTH <REST ,SOMETABLE>>
+  result = call_routine zil_context, :LENGTH, [form(:REST, form(:LVAL, :SOMETABLE))]
+
+  assert.equal! result, 2
 end
 
 def test_builtin_length_less_than_or_equal(args, assert)

--- a/samples/99_zil_interpreter/tests/eval_tests.rb
+++ b/samples/99_zil_interpreter/tests/eval_tests.rb
@@ -203,3 +203,15 @@ def test_eval_internal_false_returns_false(args, assert)
 
   assert.equal! result, false
 end
+
+def test_eval_byte_returns_byte(args, assert)
+  zil_context = build_zil_context(args)
+
+  # bytes will be interpreted by TABLE routines which are SUBRs - so BYTEs must be evaluable
+  result = eval_zil(
+    byte(22),
+    zil_context
+  )
+
+  assert.equal! result, byte(22)
+end

--- a/samples/99_zil_interpreter/tests/parser_tests_basic.rb
+++ b/samples/99_zil_interpreter/tests/parser_tests_basic.rb
@@ -539,11 +539,7 @@ def test_byte(args, assert)
 <ITABLE 59 (LEXV) 0 #BYTE 0 #BYTE 0>
   ZIL
   parsed = Parser.parse_string(source)[0]
-  expected = form(
-    :ITABLE, 59,
-    list(:LEXV),
-    0, Syntax::Byte.new(0), Syntax::Byte.new(0)
-  )
+  expected = form(:ITABLE, 59, list(:LEXV), 0, byte(0), byte(0))
 
   assert.equal! parsed, expected
 end

--- a/samples/99_zil_interpreter/tests/test_helpers.rb
+++ b/samples/99_zil_interpreter/tests/test_helpers.rb
@@ -6,6 +6,10 @@ def list(*elements)
   Syntax::List.new(*elements)
 end
 
+def byte(element)
+  Syntax::Byte.new element
+end
+
 def call_routine(context, name, args)
   context.globals[name].call args, context
 end

--- a/samples/99_zil_interpreter/tests/test_helpers.rb
+++ b/samples/99_zil_interpreter/tests/test_helpers.rb
@@ -26,3 +26,12 @@ def assert_raises_parser_error!(assert, source, assert_exception_text)
 
   raise assert_exception_text unless exception_occurred
 end
+
+def assert_function_error_with_argument_counts!(context, routine_name, counts)
+  counts.each do |argument_count|
+    call_routine context, routine_name, ['an argument'] * argument_count
+    raise "#{routine_name} did not raise FunctionError with #{argument_count} arguments"
+  rescue FunctionError
+    # Do nothing!
+  end
+end

--- a/samples/99_zil_interpreter/zil.rb
+++ b/samples/99_zil_interpreter/zil.rb
@@ -1,0 +1,2 @@
+require 'zil/array_with_offset.rb'
+require 'zil/table.rb'

--- a/samples/99_zil_interpreter/zil/array_with_offset.rb
+++ b/samples/99_zil_interpreter/zil/array_with_offset.rb
@@ -15,6 +15,10 @@ module ZIL
       @original_array[with_offset(index)] = value
     end
 
+    def size
+      @original_array.size - offset
+    end
+
     def to_a
       @original_array[@offset..-1]
     end

--- a/samples/99_zil_interpreter/zil/array_with_offset.rb
+++ b/samples/99_zil_interpreter/zil/array_with_offset.rb
@@ -5,6 +5,8 @@ module ZIL
     def initialize(original_array, offset:)
       @original_array = original_array
       @offset = offset
+      raise FunctionError, 'Cannot REST past last element' if @offset > @original_array.size
+      raise FunctionError, 'Cannot BACK past first element' if @offset.negative?
     end
 
     def [](index)
@@ -30,7 +32,7 @@ module ZIL
       when ArrayWithOffset
         new(value.original_array, offset: offset + value.offset)
       else
-        raise "REST not supported for #{value}"
+        raise FunctionError, "REST not supported for #{value}"
       end
     end
 

--- a/samples/99_zil_interpreter/zil/array_with_offset.rb
+++ b/samples/99_zil_interpreter/zil/array_with_offset.rb
@@ -1,0 +1,46 @@
+module ZIL
+  class ArrayWithOffset
+    attr_reader :original_array, :offset
+
+    def initialize(original_array, offset:)
+      @original_array = original_array
+      @offset = offset
+    end
+
+    def [](index)
+      @original_array[with_offset(index)]
+    end
+
+    def []=(index, value)
+      @original_array[with_offset(index)] = value
+    end
+
+    def to_a
+      @original_array[@offset..-1]
+    end
+
+    def self.from(value, offset:)
+      case value
+      when Array
+        new(value, offset: offset)
+      when ArrayWithOffset
+        new(value.original_array, offset: offset + value.offset)
+      else
+        raise "REST not supported for #{value}"
+      end
+    end
+
+    private
+
+    def with_offset(index)
+      case index
+      when Integer
+        return index if index.negative? # Don't offset index relative to the end
+
+        index + @offset
+      when Range
+        Range.new(with_offset(index.begin), with_offset(index.end), index.exclude_end?)
+      end
+    end
+  end
+end

--- a/samples/99_zil_interpreter/zil/table.rb
+++ b/samples/99_zil_interpreter/zil/table.rb
@@ -1,0 +1,52 @@
+module ZIL
+  module Table
+    class << self
+      def get_flags_and_values(arguments)
+        if arguments[0].is_a? Array
+          flags = arguments[0]
+          values = arguments[1..-1]
+        else
+          flags = []
+          values = arguments.dup
+        end
+
+        [flags, values]
+      end
+
+      def build(flags:, values:)
+        result = if flags.include?(:BYTE)
+                   values
+                 else
+                   values.flat_map { |value| eval_as_bytes(value) }
+                 end
+
+        prepend_length_if_necessary result, flags: flags
+        result
+      end
+
+      private
+
+      def eval_as_bytes(value)
+        if value.is_a? Syntax::Byte
+          [value.element]
+        else
+          [value, 0]
+        end
+      end
+
+      def prepend_length_if_necessary(table, flags:)
+        if flags.include? :LENGTH
+          if flags.include? :BYTE
+            table.insert(0, table.size)
+          else
+            table.insert(0, table.size.idiv(2))
+            table.insert(1, 0)
+          end
+        elsif flags.include? :LEXV
+          table.insert(0, table.size.idiv(4))
+          table.insert(1, 0)
+        end
+      end
+    end
+  end
+end

--- a/samples/99_zil_interpreter/zil/table.rb
+++ b/samples/99_zil_interpreter/zil/table.rb
@@ -10,6 +10,8 @@ module ZIL
           values = arguments.dup
         end
 
+        values << 0 if values.empty?
+
         [flags, values]
       end
 


### PR DESCRIPTION
Implemented:
- TABLE
- LTABLE
- ITABLE
- GET
- PUT
- GETB
- PUTB
- NTH
- REST
- BACK
- EMPTY?
- LENGTH
- LENGTH?
- PUTREST

I'm using a simple array or a wrapper with the same interface (for offset tables/list) as representation - that should be hopefully enough from what I saw from the zork source code